### PR TITLE
src/opus: Force precise floating-point for opus_pcm_soft_clip (vs2015)

### DIFF
--- a/src/opus.c
+++ b/src/opus.c
@@ -33,6 +33,7 @@
 #include "opus_private.h"
 
 #ifndef DISABLE_FLOAT_API
+#pragma float_control(precise, on, push)
 OPUS_EXPORT void opus_pcm_soft_clip(float *_x, int N, int C, float *declip_mem)
 {
    int c;
@@ -131,6 +132,7 @@ OPUS_EXPORT void opus_pcm_soft_clip(float *_x, int N, int C, float *declip_mem)
       declip_mem[c] = a;
    }
 }
+#pragma float_control(pop)
 #endif
 
 int encode_size(int size, unsigned char *data)


### PR DESCRIPTION
Fixes failed test in test_opus_decode when using fp:fast.
Suggested in #14

This test also fails when compiled with GCC 5.4 with -ffast-math.