### PR TITLE
appveyor: don't leave artifacts under a subdir

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ after_build:
 
     cd %APPVEYOR_BUILD_FOLDER%
 
-    7z a opus.zip artifacts\* include\*.h
+    7z a opus.zip .\artifacts\* include\*.h
 
 test_script:
 - cmd: >-


### PR DESCRIPTION
Better wait for appveyor to finish building before merging this time.