### PR TITLE
Avoid warning when __STDC_VERSION__ is not defined

### DIFF
--- a/include/opus_types.h
+++ b/include/opus_types.h
@@ -34,7 +34,7 @@
 #define OPUS_TYPES_H
 
 /* Use the real stdint.h if it's there (taken from Paul Hsieh's pstdint.h) */
-#if (defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_)) || defined (HAVE_STDINT_H))
+#if (defined(__STDC__) && __STDC__ && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_)) || defined (HAVE_STDINT_H))
 #include <stdint.h>
 
    typedef int16_t opus_int16;


### PR DESCRIPTION
This fixes a warning when building with GCC:
```

[....]  include/opus_types.h:37:39: error: "__STDC_VERSION__" is not defined [-Werror=undef]
 #if (defined(__STDC__) && __STDC__ && __STDC_VERSION__ >= 199901L) || (defined(__GNUC__) && (defined(_STDINT_H) || defined(_STDINT_H_)) || defined (HAVE_STDINT_H))
                                       ^

```