### PR TITLE
appveyor: fix typoed appveyor command

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,4 +34,4 @@ artifacts:
 - path: opus.zip
 
 on_success:
-- appveyor Start-AppveyorBuild -ApiKey %API_KEY% -ProjectSlug opus-tools
+- ps: if ($env:api_key -and "$env:configuration/$env:platform" -eq "ReleaseDLL_fixed/x64") { Start-AppveyorBuild -ApiKey $env:api_key -ProjectSlug 'opus-tools' }


### PR DESCRIPTION
@rillian  I can't test the request with your API key because encrypted variables from another account don't work, but I tested with mine and I'm pretty sure it will work now.