### PR TITLE
Force crlf line endings for VS2015 project files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,9 @@
 .gitattributes		export-ignore
 
 update_version		export-ignore
+
+*.bat eol=crlf
+*.sln eol=crlf
+*.vcxproj eol=crlf
+*.vcxproj.filters eol=crlf
+common.props eol=crlf


### PR DESCRIPTION
this ensures that regardless of git settings VS project files have correct line endings. This make VS to use correct version of visual studio.