### PR TITLE
Fixed twice assigned

### DIFF
--- a/celt/celt_encoder.c
+++ b/celt/celt_encoder.c
@@ -1454,7 +1454,7 @@ int celt_encode_with_ec(CELTEncoder * OPUS_RESTRICT st, const opus_val16 * pcm, 
       tell0_frac=tell=1;
       nbFilledBytes=0;
    } else {
-      tell0_frac=tell=ec_tell_frac(enc);
+      tell0_frac=ec_tell_frac(enc);
       tell=ec_tell(enc);
       nbFilledBytes=(tell+4)>>3;
    }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warning, found using PVS-Studio:
opus/celt/celt_encoder.c    1458    warn    V519 The 'tell' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 1457, 1458.