### PR TITLE
Proper detection of _mm_cvtss_si32 for MS compiler

### DIFF
--- a/celt/float_cast.h
+++ b/celt/float_cast.h
@@ -96,10 +96,10 @@ static OPUS_INLINE opus_int32 float2int(float x) {return _mm_cvt_ss2si(_mm_set_s
 #include <math.h>
 #define float2int(x) lrint(x)
 
-#elif (defined(_MSC_VER) && _MSC_VER >= 1400) && defined (_M_X64)
+#elif (defined(_MSC_VER) && _MSC_VER >= 1400) && (defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 1))
         #include <xmmintrin.h>
 
-        __inline long int float2int(float value)
+        static __inline long int float2int(float value)
         {
                 return _mm_cvtss_si32(_mm_load_ss(&value));
         }
@@ -110,16 +110,14 @@ static OPUS_INLINE opus_int32 float2int(float x) {return _mm_cvt_ss2si(_mm_set_s
         **      Therefore implement OPUS_INLINE versions of these functions here.
         */
 
-        __inline long int
-        float2int (float flt)
-        {       int intgr;
-
+        static __inline long int float2int (float flt)
+        {
+                int intgr;
                 _asm
                 {       fld flt
                         fistp intgr
-                } ;
-
-                return intgr ;
+                };
+                return intgr;
         }
 
 #else


### PR DESCRIPTION
_mm_cvtss_si32 is available starting from SSE