### PR TITLE
Remove requirement to add fixed and float dirs to include path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ lib_LTLIBRARIES = libopus.la
 DIST_SUBDIRS = doc
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/celt -I$(top_srcdir)/silk \
-              -I$(top_srcdir)/silk/float -I$(top_srcdir)/silk/fixed $(NE10_CFLAGS)
+              $(NE10_CFLAGS)
 
 include celt_sources.mk
 include silk_sources.mk

--- a/Makefile.mips
+++ b/Makefile.mips
@@ -52,9 +52,6 @@ CINCLUDES = include silk celt
 
 ifdef FIXED_POINT
 CFLAGS += -DFIXED_POINT=1 -DDISABLE_FLOAT_API
-CINCLUDES += silk/fixed
-else
-CINCLUDES += silk/float
 endif
 
 

--- a/Makefile.unix
+++ b/Makefile.unix
@@ -50,9 +50,6 @@ CINCLUDES = include silk celt
 
 ifdef FIXED_POINT
 CFLAGS += -DFIXED_POINT=1 -DDISABLE_FLOAT_API
-CINCLUDES += silk/fixed
-else
-CINCLUDES += silk/float
 endif
 
 

--- a/silk/HP_variable_cutoff.c
+++ b/silk/HP_variable_cutoff.c
@@ -29,9 +29,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 #endif
 #ifdef FIXED_POINT
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 #else
-#include "main_FLP.h"
+#include "float/main_FLP.h"
 #endif
 #include "tuning_parameters.h"
 

--- a/silk/arm/arm_silk_map.c
+++ b/silk/arm/arm_silk_map.c
@@ -28,7 +28,7 @@ POSSIBILITY OF SUCH DAMAGE.
 # include "config.h"
 #endif
 
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 #include "NSQ.h"
 #include "SigProc_FIX.h"
 

--- a/silk/control_codec.c
+++ b/silk/control_codec.c
@@ -29,10 +29,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 #endif
 #ifdef FIXED_POINT
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 #define silk_encoder_state_Fxx      silk_encoder_state_FIX
 #else
-#include "main_FLP.h"
+#include "float/main_FLP.h"
 #define silk_encoder_state_Fxx      silk_encoder_state_FLP
 #endif
 #include "stack_alloc.h"

--- a/silk/enc_API.c
+++ b/silk/enc_API.c
@@ -36,9 +36,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "structs.h"
 #include "tuning_parameters.h"
 #ifdef FIXED_POINT
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 #else
-#include "main_FLP.h"
+#include "float/main_FLP.h"
 #endif
 
 /***************************************/

--- a/silk/fixed/arm/warped_autocorrelation_FIX_neon_intr.c
+++ b/silk/fixed/arm/warped_autocorrelation_FIX_neon_intr.c
@@ -34,7 +34,7 @@ POSSIBILITY OF SUCH DAMAGE.
 # include <string.h>
 #endif
 #include "stack_alloc.h"
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 
 static OPUS_INLINE void calc_corr( const opus_int32 *const input_QS, opus_int64 *const corr_QC, const opus_int offset, const int32x4_t state_QS_s32x4 )
 {

--- a/silk/fixed/mips/prefilter_FIX_mipsr1.h
+++ b/silk/fixed/mips/prefilter_FIX_mipsr1.h
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 #endif
 
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 #include "stack_alloc.h"
 #include "tuning_parameters.h"
 

--- a/silk/fixed/mips/warped_autocorrelation_FIX_mipsr1.h
+++ b/silk/fixed/mips/warped_autocorrelation_FIX_mipsr1.h
@@ -32,7 +32,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 #endif
 
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 
 #undef QC
 #define QC  10

--- a/silk/init_encoder.c
+++ b/silk/init_encoder.c
@@ -29,9 +29,9 @@ POSSIBILITY OF SUCH DAMAGE.
 #include "config.h"
 #endif
 #ifdef FIXED_POINT
-#include "main_FIX.h"
+#include "fixed/main_FIX.h"
 #else
-#include "main_FLP.h"
+#include "float/main_FLP.h"
 #endif
 #include "tuning_parameters.h"
 #include "cpu_support.h"

--- a/win32/VS2015/opus.vcxproj
+++ b/win32/VS2015/opus.vcxproj
@@ -158,7 +158,6 @@
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\silk\fixed;..\..\silk\float;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(ConfigurationType)'=='DynamicLibrary'">DLL_EXPORT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)'=='DebugDLL_fixed' or '$(Configuration)'=='ReleaseDLL_fixed'">FIXED_POINT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/arch:IA32 %(AdditionalOptions)</AdditionalOptions>


### PR DESCRIPTION
I didn't try to build other platforms, works for me on mac/windows.

In case if somebody simply includes opus src code this change makes life easier.