### PR TITLE
Avoid DTX when Silk sees activity

### DIFF
--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -2129,6 +2129,12 @@ opus_int32 opus_encode_native(OpusEncoder *st, const opus_val16 *pcm, int frame_
 #ifndef DISABLE_FLOAT_API
     if (st->use_dtx && (analysis_info.valid || is_silence))
     {
+       /* Mark the frame active if Silk considers it active */
+       if(st->mode != MODE_CELT_ONLY && st->silk_mode.signalType != TYPE_NO_VOICE_ACTIVITY)
+       {
+          analysis_info.activity_probability = 1.0f;
+       }
+
        if (decide_dtx_mode(analysis_info.activity_probability, &st->nb_no_activity_frames,
              st->peak_signal_energy, pcm, frame_size, st->channels, is_silence, st->arch))
        {


### PR DESCRIPTION
This PR fixes an issue with periodic clicks or noise-bursts during DTX that we have seen in Chrome, AppRTC and other WebRTC clients.

Sometimes, Opus (in silk-only or hybrid mode) decides to go into DTX even though Silk considers the signal to contain activity. This is because the `decide_dtx_mode` has a different VAD than Silk.

In DTX, Opus sends an encoded packet every 420 ms. This is in order to give an updated estimation of the background noise. The decoder uses comfort noise (CNG) to produce output during the DTX period.

However, when the silk layer of the "update packets" that arrive every 420 ms contain activity (type `TYPE_UNVOICED` or `TYPE_VOICED` instead of `TYPE_NO_VOICE_ACTIVITY`) the decoder will instead use packet loss concealment (PLC) to produce output instead of CNG. The PLC is then faded out as CNG ramps up.

In cases when several update packets contain activity, the switching back and forth between PLC and CNG will cause an audible click or noise-burst every 420 ms.

This PR fixes the issue by preventing Opus from entering DTX in hybrid or silk-only mode whenever silk considers the signal to be active. Celt-only mode is unaffected.