### PR TITLE
Trivial sprintf to snprintf conversion.

### DIFF
--- a/tests/test_opus_encode.c
+++ b/tests/test_opus_encode.c
@@ -236,7 +236,7 @@ void fuzz_encoder_settings(const int num_encoders, const int num_setting_changes
          int frame_size_enum = get_frame_size_enum(frame_size, sampling_rate);
          force_channel = IMIN(force_channel, num_channels);
 
-         sprintf(debug_info,
+         snprintf(debug_info, sizeof(debug_info),
                  "fuzz_encoder_settings: %d kHz, %d ch, application: %d, "
                  "%d bps, force ch: %d, vbr: %d, vbr constraint: %d, complexity: %d, "
                  "max bw: %d, signal: %d, inband fec: %d, pkt loss: %d%%, lsb depth: %d, "


### PR DESCRIPTION
Some linkers warn about unbounded sprintf calls, like the OpenBSD linker.

Since snprintf() is already used in other places in the same file, I assume availability of snprintf() isn't an issue, and the size of the buffer is knowable at that point so, trivial conversion, and slightly less warnings while compiling on openbsd.

Tested on macosx x86_64 (took a minute or so), and OpenBSD/mips64 (took the whole weekend) with all 14 tests passing ok on "make check".
