### PR TITLE
mips:  Rename MIPSr1_ASM to MIPSr2dsp_ASM to reflect true requirements.

### DIFF
--- a/Makefile.mips
+++ b/Makefile.mips
@@ -46,7 +46,7 @@ ldlibs-from-libs        = $(addprefix -l,$(1))
 
 WARNINGS = -Wall -W -Wstrict-prototypes -Wextra -Wcast-align -Wnested-externs -Wshadow
 
-CFLAGS  += -mips32r2 -mno-mips16 -std=gnu99 -O2 -g $(WARNINGS) -DENABLE_ASSERTIONS -DMIPSr1_ASM -DOPUS_BUILD -mdspr2 -march=74kc -mtune=74kc -mmt -mgp32
+CFLAGS  += -mips32r2 -mno-mips16 -std=gnu99 -O2 -g $(WARNINGS) -DENABLE_ASSERTIONS -DMIPSr2dsp_ASM -DOPUS_BUILD -mdsp -march=74kc -mtune=74kc -mmt -mgp32
 
 CINCLUDES = include silk celt
 

--- a/celt/_kiss_fft_guts.h
+++ b/celt/_kiss_fft_guts.h
@@ -97,7 +97,7 @@
 #if defined(OPUS_ARM_INLINE_EDSP)
 #include "arm/kiss_fft_armv5e.h"
 #endif
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/kiss_fft_mipsr1.h"
 #endif
 

--- a/celt/celt.c
+++ b/celt/celt.c
@@ -54,7 +54,7 @@
 #define PACKAGE_VERSION "unknown"
 #endif
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/celt_mipsr1.h"
 #endif
 

--- a/celt/fixed_generic.h
+++ b/celt/fixed_generic.h
@@ -162,7 +162,7 @@
 /** Divide a 32-bit value by a 32-bit value. Result fits in 32 bits */
 #define DIV32(a,b) (((opus_val32)(a))/((opus_val32)(b)))
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/fixed_generic_mipsr1.h"
 #endif
 

--- a/celt/mdct.c
+++ b/celt/mdct.c
@@ -53,7 +53,7 @@
 #include "mathops.h"
 #include "stack_alloc.h"
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/mdct_mipsr1.h"
 #endif
 

--- a/celt/pitch.h
+++ b/celt/pitch.h
@@ -42,7 +42,7 @@
 #include "x86/pitch_sse.h"
 #endif
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/pitch_mipsr1.h"
 #endif
 

--- a/celt/vq.h
+++ b/celt/vq.h
@@ -41,7 +41,7 @@
 #include "x86/vq_sse.h"
 #endif
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/vq_mipsr1.h"
 #endif
 

--- a/silk/NSQ_del_dec.c
+++ b/silk/NSQ_del_dec.c
@@ -61,7 +61,7 @@ typedef struct {
 
 typedef NSQ_sample_struct  NSQ_sample_pair[ 2 ];
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/NSQ_del_dec_mipsr1.h"
 #endif
 static OPUS_INLINE void silk_nsq_del_dec_scale_states(

--- a/silk/SigProc_FIX.h
+++ b/silk/SigProc_FIX.h
@@ -629,7 +629,7 @@ static OPUS_INLINE opus_int64 silk_max_64(opus_int64 a, opus_int64 b)
 #include "arm/SigProc_FIX_armv5e.h"
 #endif
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/sigproc_fix_mipsr1.h"
 #endif
 

--- a/silk/fixed/noise_shape_analysis_FIX.c
+++ b/silk/fixed/noise_shape_analysis_FIX.c
@@ -129,7 +129,7 @@ static OPUS_INLINE void limit_warped_coefs(
 }
 
 /* Disable MIPS version until it's updated. */
-#if 0 && defined(MIPSr1_ASM)
+#if 0 && defined(MIPSr2dsp_ASM)
 #include "mips/noise_shape_analysis_FIX_mipsr1.h"
 #endif
 

--- a/silk/fixed/warped_autocorrelation_FIX.c
+++ b/silk/fixed/warped_autocorrelation_FIX.c
@@ -31,7 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "main_FIX.h"
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/warped_autocorrelation_FIX_mipsr1.h"
 #endif
 

--- a/silk/macros.h
+++ b/silk/macros.h
@@ -104,7 +104,7 @@ POSSIBILITY OF SUCH DAMAGE.
                                         (( (a) & ((b)^0x80000000) & 0x80000000) ? silk_int32_MIN : (a)-(b)) :    \
                                         ((((a)^0x80000000) & (b)  & 0x80000000) ? silk_int32_MAX : (a)-(b)) )
 
-#if defined(MIPSr1_ASM)
+#if defined(MIPSr2dsp_ASM)
 #include "mips/macros_mipsr1.h"
 #endif
 


### PR DESCRIPTION
All of the mips code in opus requires a mips32r2 core with dsp or dsp2 extensions, so
update the #define to document this appropriately.

I did not rename the various header files that have "mipsr1" in their name, as that seemed like unnecessary churn. 

Signed-off-by: Solomon Peachy <pizza@shaftnet.org>