### PR TITLE
CMake - If CMAKE_BUILD_TYPE is empty and CFlags are set then only use…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 
-include(opus_buildtype.cmake)
 include(opus_functions.cmake)
 
 get_library_version(OPUS_LIBRARY_VERSION OPUS_LIBRARY_VERSION_MAJOR)
@@ -17,6 +16,7 @@ string(REGEX
 message(STATUS "Opus project version: ${PROJECT_VERSION}")
 
 project(Opus LANGUAGES C VERSION ${PROJECT_VERSION})
+include(opus_buildtype.cmake)
 
 option(OPUS_STACK_PROTECTOR "Use stack protection" ON)
 option(OPUS_USE_ALLOCA "Use alloca for stack arrays (on non-C99 compilers)" OFF)

--- a/opus_buildtype.cmake
+++ b/opus_buildtype.cmake
@@ -1,18 +1,23 @@
 # Set a default build type if none was specified
-set(default_build_type "Release")
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(
-    STATUS
-      "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}"
-      CACHE STRING "Choose the type of build."
-      FORCE)
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE
-               PROPERTY STRINGS
-                        "Debug"
-                        "Release"
-                        "MinSizeRel"
-                        "RelWithDebInfo")
+  if(CMAKE_C_FLAGS)
+    message(STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS})
+  else()
+    set(default_build_type "Release")
+    message(
+      STATUS
+        "Setting build type to '${default_build_type}' as none was specified and no CFLAGS was exported."
+      )
+    set(CMAKE_BUILD_TYPE "${default_build_type}"
+        CACHE STRING "Choose the type of build."
+        FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE
+                 PROPERTY STRINGS
+                          "Debug"
+                          "Release"
+                          "MinSizeRel"
+                          "RelWithDebInfo")
+  endif()
 endif()


### PR DESCRIPTION
CMake - If CMAKE_BUILD_TYPE is empty and CFlags are set then only use CFlags. If None are set then use CMAKE_BUILD_TYPE by Release by default.

