### PR TITLE
CMake: Add alias Opus::opus for opus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ feature_summary(WHAT ALL)
 
 add_library(opus ${opus_sources} ${opus_sources_float})
 
+add_library(Opus::opus ALIAS opus)
+
 set(Opus_PUBLIC_HEADER
     ${CMAKE_CURRENT_SOURCE_DIR}/include/opus.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/opus_custom.h


### PR DESCRIPTION
One of the common patterns in CMake 3.x is the "superbuild" pattern, where the source trees of a dependencies are nested under a master project. In order for the projects to be modular (be agnostic to whether or not the dependencies are nested or not), the in-tree build process needs to generate the same targets as finding the dependencies out of tree. For example:

```
cmake_minimum_required(VERSION 3.14)
project(opus-example VERSION 0.0.1 LANGUAGES CXX)

option(USE_SYSTEM_OPUS "Use the system opus" OFF)

if (USE_SYSTEM_OPUS)
    find_package(Opus REQUIRED)
else ()
    add_subdirectory(${PROJECT_SOURCE_DIR}/dependencies/opus)
endif()

add_executable(example ${PROJECT_SOURCE_DIR}/src/example.cpp)
target_link_libraries(example PRIVATE Opus::opus)
```
Using find_package to find Opus will create the Opus::opus target, but adding the source code directly only adds opus. Aliasing opus to Opus::opus lets you keep the target_link_libraries line the same regardless of the source of the dependency.

