### PR TITLE
Close warning in opus_encoder.c while enable fuzzing

### DIFF
--- a/celt/rate.c
+++ b/celt/rate.c
@@ -348,6 +348,7 @@ static OPUS_INLINE int interp_bits2pulses(const CELTMode *m, int start, int end,
             /*This if() block is the only part of the allocation function that
                is not a mandatory part of the bitstream: any bands we choose to
                skip here must be explicitly signaled.*/
+#ifndef FUZZING
             int depth_threshold;
             /*We choose a threshold with some hysteresis to keep bands from
                fluctuating in and out, but we try not to fold below a certain point. */
@@ -355,10 +356,9 @@ static OPUS_INLINE int interp_bits2pulses(const CELTMode *m, int start, int end,
                depth_threshold = j<prev ? 7 : 9;
             else
                depth_threshold = 0;
-#ifdef FUZZING
-            if ((rand()&0x1) == 0)
-#else
             if (codedBands<=start+2 || (band_bits > (depth_threshold*band_width<<LM<<BITRES)>>4 && j<=signalBandwidth))
+#else
+            if ((rand()&0x1) == 0)
 #endif
             {
                ec_enc_bit_logp(ec, 1, 1);

--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -1097,7 +1097,9 @@ opus_int32 opus_encode_native(OpusEncoder *st, const opus_val16 *pcm, int frame_
     opus_val16 HB_gain;
     opus_int32 max_data_bytes; /* Max number of bytes we're allowed to use */
     int total_buffer;
+#ifndef FUZZING
     opus_val16 stereo_width;
+#endif
     const CELTMode *celt_mode;
 #ifndef DISABLE_FLOAT_API
     AnalysisInfo analysis_info;
@@ -1204,10 +1206,12 @@ opus_int32 opus_encode_native(OpusEncoder *st, const opus_val16 *pcm, int frame_
     st->voice_ratio = -1;
 #endif
 
+#ifndef FUZZING
     if (st->channels==2 && st->force_channels!=1)
        stereo_width = compute_stereo_width(pcm, frame_size, st->Fs, &st->width_mem);
     else
        stereo_width = 0;
+#endif
     total_buffer = delay_compensation;
     st->bitrate_bps = user_bitrate_to_bitrate(st, frame_size, max_data_bytes);
 

--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -146,6 +146,8 @@ static const opus_int32 stereo_music_bandwidth_thresholds[8] = {
         11000, 1000, /* WB<->SWB */
         12000, 2000, /* SWB<->FB */
 };
+
+#ifndef FUZZING
 /* Threshold bit-rates for switching between mono and stereo */
 static const opus_int32 stereo_voice_threshold = 19000;
 static const opus_int32 stereo_music_threshold = 17000;
@@ -156,6 +158,7 @@ static const opus_int32 mode_thresholds[2][2] = {
       {  64000,      10000}, /* mono */
       {  44000,      10000}, /* stereo */
 };
+#endif
 
 static const opus_int32 fec_thresholds[] = {
         12000, 1000, /* NB */


### PR DESCRIPTION
stereo_voice_threshold, stereo_music_threhold and mode_threshold, these var only used in fuzzing.