### PR TITLE
configure: adjust x86 get cpu info inline assembly method for PIC case

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -691,6 +691,18 @@ AS_IF([test x"$enable_intrinsics" = x"yes"],[
                  unsigned int CPUInfo2;
                  unsigned int CPUInfo3;
                  unsigned int InfoType;
+                #if defined(__i386__) && defined(__PIC__)
+                 __asm__ __volatile__ (
+                 "xchg %%ebx, %1\n"
+                 "cpuid\n"
+                 "xchg %%ebx, %1\n":
+                 "=a" (CPUInfo0),
+                 "=r" (CPUInfo1),
+                 "=c" (CPUInfo2),
+                 "=d" (CPUInfo3) :
+                 "a" (InfoType), "c" (0)
+                );
+               #else
                  __asm__ __volatile__ (
                  "cpuid":
                  "=a" (CPUInfo0),
@@ -699,6 +711,7 @@ AS_IF([test x"$enable_intrinsics" = x"yes"],[
                  "=d" (CPUInfo3) :
                  "a" (InfoType), "c" (0)
                 );
+               #endif
             ]])],
             [get_cpuid_by_asm="yes"
              AC_MSG_RESULT([Inline Assembly])


### PR DESCRIPTION
With old Darwin gcc versions 4.0.1 and 4.2.1, I get:
`checking How to get X86 CPU Info... configure: error: no supported Get CPU Info method, please disable run-time CPU capabilities detection or intrinsics`

config.log has:
```
conftest.c:41: error: can't find a register in class 'BREG' while reloading 'asm'
conftest.c:41: error: 'asm' operand has impossible constraints
```
Adjusting the tested code to deal with PIC case (just like the way it
is done in celt/x86/x86cpu.c) cures it.
