### PR TITLE
set stop when last frame

### DIFF
--- a/src/opus_demo.c
+++ b/src/opus_demo.c
@@ -689,7 +689,7 @@ int main(int argc, char *argv[])
                 s=((s&0xFFFF)^0x8000)-0x8000;
                 in[i+remaining*channels]=s;
             }
-            if (curr_read+remaining < frame_size)
+            if (curr_read+remaining <= frame_size)
             {
                 for (i=(curr_read+remaining)*channels;i<frame_size*channels;i++)
                    in[i] = 0;


### PR DESCRIPTION
Change code in opus_demo.c
It won't set stop=1 when last frame has the same size of the frame_size, which means `curr_read+remaining = frame_size` and `remaining = 0`. And in this situation, it encode an extra all 0 frame