### PR TITLE
cmake/CFeatureCheck.cmake: fix feature tests failing when Opus is a submodule

### DIFF
--- a/cmake/CFeatureCheck.cmake
+++ b/cmake/CFeatureCheck.cmake
@@ -27,7 +27,7 @@ function(c_feature_check FILE)
 
   if (NOT DEFINED COMPILE_${FEATURE})
       message(STATUS "Performing Test ${FEATURE}")
-      try_compile(COMPILE_${FEATURE} ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/${FILE}.c)
+      try_compile(COMPILE_${FEATURE} ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/${FILE}.c)
   endif()
 
   if(COMPILE_${FEATURE})


### PR DESCRIPTION
`CMAKE_SOURCE_DIR` corresponds to the top project's source directory.
`CMAKE_BINARY_DIR` corresponds to the top project's binary directory.

The usage of these variables doesn't cause any problems when Opus is built as a standalone project.

This is not the case when Opus is added as submodule: the variables are set by the project that calls `add_subdirectory()`.

The fix consists in using `PROJECT_SOURCE_DIR` and `PROJECT_BINARY_DIR`, which always refer to the current project.