### PR TITLE
CFeatureCheck: Use CMAKE_CURRENT_SOURCE_DIR, not CMAKE_SOURCE_DIR

### DIFF
--- a/cmake/CFeatureCheck.cmake
+++ b/cmake/CFeatureCheck.cmake
@@ -27,7 +27,7 @@ function(c_feature_check FILE)
 
   if (NOT DEFINED COMPILE_${FEATURE})
       message(STATUS "Performing Test ${FEATURE}")
-      try_compile(COMPILE_${FEATURE} ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/${FILE}.c)
+      try_compile(COMPILE_${FEATURE} ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${FILE}.c)
   endif()
 
   if(COMPILE_${FEATURE})


### PR DESCRIPTION
The latter gets the directory of the outermost CMakeLists.txt. In the case where
libopus is submoduled into another project and libopus is add_subdirectory'd, this
means feature check will look in the parent project instead of this project's 'cmake'
folder for a feature check c file. Changing to the former fixes this.