### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,7 +490,7 @@ if(OPUS_INSTALL_CMAKE_CONFIG_MODULE)
   include(CMakePackageConfigHelpers)
 
   set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
-  configure_package_config_file(${CMAKE_SOURCE_DIR}/cmake/OpusConfig.cmake.in
+  configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/OpusConfig.cmake.in
                                 OpusConfig.cmake
                                 INSTALL_DESTINATION
                                 ${CMAKE_INSTALL_PACKAGEDIR}

--- a/cmake/OpusConfig.cmake
+++ b/cmake/OpusConfig.cmake
@@ -5,7 +5,7 @@ set(__opus_config INCLUDED)
 
 include(OpusFunctions)
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/config.h.cmake.in config.h @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.h.cmake.in config.h @ONLY)
 add_definitions(-DHAVE_CONFIG_H)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
This will make it easy to build opus together with a project. As of now, I could not do it until I made this change on the repository CMake files. Otherwise, I'd keep getting relative path errors. Not sure if that has any negative effect over the current build procedure, though. Please let me know.