### PR TITLE
Fix compilation when used as static library

### DIFF
--- a/opus.pc.in
+++ b/opus.pc.in
@@ -11,6 +11,6 @@ URL: https://opus-codec.org/
 Version: @VERSION@
 Requires:
 Conflicts:
-Libs: -L${libdir} -lopus
+Libs: -L${libdir} -lopus @LIBM@
 Libs.private: @LIBM@
 Cflags: -I${includedir}/opus


### PR DESCRIPTION
I tried to compile ffmpeg with a static version of libopus, but it fails due to unresolved libmath references in configure checks.
From the manpage I cannot really see wether `-lm` is supposed to be in `Libs` and `Libs.private` but other projects do it like this, see: https://github.com/webmproject/libvpx/blob/master/libs.mk#L374

So I'd like to propose this change to fix the issue I see.