### PR TITLE
Meson: Fix doc build when opus is a subproject

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,3 @@
-top_srcdir = meson.source_root()
-top_builddir = meson.build_root()
-
 have_dot = find_program('dot', required: false).found()
 
 doxyfile_conf = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,8 @@ macosversion = run_command('meson/get-version.py', '--darwin-version', check: tr
 cc = meson.get_compiler('c')
 host_system = host_machine.system()
 host_cpu_family = host_machine.cpu_family()
+top_srcdir = meson.current_source_dir()
+top_builddir = meson.current_build_dir()
 
 opus_includes = include_directories('.', 'include', 'celt', 'silk')
 opus_public_includes = include_directories('include')


### PR DESCRIPTION
meson.source_root() and meson.build_root() have been deprecated in
latest Meson release because they are a trap. They point to the root of
parent project instead of root of current subproject. Meson 0.56.0 added
meson.project_source/build_root() but it is just as easy to use
meson.current_source/build_dir() in the root meson.build file and avoids
bumping required meson version.