### PR TITLE
docs: fix simple typo, neareast -> nearest

### DIFF
--- a/celt/fixed_generic.h
+++ b/celt/fixed_generic.h
@@ -102,9 +102,9 @@
 
 #define SATURATE16(x) (EXTRACT16((x)>32767 ? 32767 : (x)<-32768 ? -32768 : (x)))
 
-/** Shift by a and round-to-neareast 32-bit value. Result is a 16-bit value */
+/** Shift by a and round-to-nearest 32-bit value. Result is a 16-bit value */
 #define ROUND16(x,a) (EXTRACT16(PSHR32((x),(a))))
-/** Shift by a and round-to-neareast 32-bit value. Result is a saturated 16-bit value */
+/** Shift by a and round-to-nearest 32-bit value. Result is a saturated 16-bit value */
 #define SROUND16(x,a) EXTRACT16(SATURATE(PSHR32(x,a), 32767));
 
 /** Divide by two */


### PR DESCRIPTION
There is a small typo in celt/fixed_generic.h.

Should read `nearest` rather than `neareast`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md