### PR TITLE
Sending refresh DTX packets every 400 ms independently of the encoded…

### DIFF
--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -112,7 +112,7 @@ struct OpusEncoder {
     opus_val16   delay_buffer[MAX_ENCODER_BUFFER*2];
 #ifndef DISABLE_FLOAT_API
     int          detected_bandwidth;
-    int          nb_no_activity_frames;
+    int          nb_no_activity_ms_Q1;
     opus_val32   peak_signal_energy;
 #endif
     int          nonfinal_frame; /* current frame is not the final in a packet */
@@ -893,24 +893,28 @@ static opus_val32 compute_frame_energy(const opus_val16 *pcm, int frame_size, in
 
 /* Decides if DTX should be turned on (=1) or off (=0) */
 static int decide_dtx_mode(opus_int activity,            /* indicates if this frame contains speech/music */
-                           int *nb_no_activity_frames    /* number of consecutive frames with no activity */
+                           int *nb_no_activity_ms_Q1,    /* number of consecutive milliseconds with no activity, in Q1 */
+                           int frame_size_ms_Q1          /* number of miliseconds in this update, in Q1 */
                            )
 
 {
    if (!activity)
    {
-      /* The number of consecutive DTX frames should be within the allowed bounds */
-      (*nb_no_activity_frames)++;
-      if (*nb_no_activity_frames > NB_SPEECH_FRAMES_BEFORE_DTX)
+      /* The number of consecutive DTX frames should be within the allowed bounds. 
+      Note that the allowed bound is defined in the Silk headers and assumes 20 ms
+      frames. As this function can be called with any frame length, a conversion to
+      miliseconds is done before the comparisons. */
+      (*nb_no_activity_ms_Q1) += frame_size_ms_Q1;
+      if (*nb_no_activity_ms_Q1 > NB_SPEECH_FRAMES_BEFORE_DTX*20*2)
       {
-         if (*nb_no_activity_frames <= (NB_SPEECH_FRAMES_BEFORE_DTX + MAX_CONSECUTIVE_DTX))
+         if (*nb_no_activity_ms_Q1 <= (NB_SPEECH_FRAMES_BEFORE_DTX + MAX_CONSECUTIVE_DTX)*20*2)
             /* Valid frame for DTX! */
             return 1;
          else
-            (*nb_no_activity_frames) = NB_SPEECH_FRAMES_BEFORE_DTX;
+            (*nb_no_activity_ms_Q1) = NB_SPEECH_FRAMES_BEFORE_DTX*20*2;
       }
    } else
-      (*nb_no_activity_frames) = 0;
+      (*nb_no_activity_ms_Q1) = 0;
 
    return 0;
 }
@@ -2132,7 +2136,7 @@ opus_int32 opus_encode_native(OpusEncoder *st, const opus_val16 *pcm, int frame_
 #ifndef DISABLE_FLOAT_API
     if (st->use_dtx && (analysis_info.valid || is_silence))
     {
-       if (decide_dtx_mode(activity, &st->nb_no_activity_frames))
+       if (decide_dtx_mode(activity, &st->nb_no_activity_ms_Q1, 2*1000*frame_size/st->Fs))
        {
           st->rangeFinal = 0;
           data[0] = gen_toc(st->mode, st->Fs/frame_size, curr_bandwidth, st->stream_channels);
@@ -2140,7 +2144,7 @@ opus_int32 opus_encode_native(OpusEncoder *st, const opus_val16 *pcm, int frame_
           return 1;
        }
     } else {
-       st->nb_no_activity_frames = 0;
+       st->nb_no_activity_ms_Q1 = 0;
     }
 #endif
 
@@ -2733,7 +2737,7 @@ int opus_encoder_ctl(OpusEncoder *st, int request, ...)
 #ifndef DISABLE_FLOAT_API
             else if (st->use_dtx) {
                 /* DTX determined by Opus. */
-                *value = st->nb_no_activity_frames >= NB_SPEECH_FRAMES_BEFORE_DTX;
+                *value = st->nb_no_activity_ms_Q1 >= NB_SPEECH_FRAMES_BEFORE_DTX*20*2;
             }
 #endif
             else {


### PR DESCRIPTION
… frame size.

This pull request makes sure that refresh DTX packets are sent every 400 ms. When encoding with frame sizes different from 20 ms and using Silk (for example by forcing a low bitrate) the distance between refresh DTX packets was different from 400 ms. Specifically, for frames length equal to 60 ms, the packets were at 1.2 seconds distance.

As an example, the attached image compares a DTX region before and after the change proposed in this pull request. We can see that the upper image did not receive a refresh DTX packet for 1.2 second and, therefore, kept a high level of comfort noise for longer time. The bottom spectrogram was created with the proposed changes. 

![example_DTX_packet_duration](https://user-images.githubusercontent.com/32208189/107776135-7c430180-6d41-11eb-9705-8b3f9d129f97.png)


