### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README
+++ b/README
@@ -133,6 +133,18 @@ To run compare the code to these test vectors:
     % tar -zxf opus_testvectors-rfc8251.tar.gz
     % ./tests/run_vectors.sh ./ opus_newvectors 48000
 
+== Installing opus (vcpkg) ==
+
+Alternatively, you can build and install opus using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    % git clone https://github.com/Microsoft/vcpkg.git
+    % cd vcpkg
+    % ./bootstrap-vcpkg.sh
+    % ./vcpkg integrate install
+    % ./vcpkg install opus
+
+The opus port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 == Portability notes ==
 
 This implementation uses floating-point by default but can be compiled to


### PR DESCRIPTION
`opus` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `opus` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `opus`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/opus/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 😊