### PR TITLE
Meson: Fix unknown variable have_arm_intrinsics_or_asm

### DIFF
--- a/silk/meson.build
+++ b/silk/meson.build
@@ -25,6 +25,11 @@ if host_cpu_family in ['x86', 'x86_64'] and opus_conf.has('OPUS_HAVE_RTCD')
   silk_sources +=  sources['SILK_SOURCES_X86_RTCD']
 endif
 
+have_arm_intrinsics_or_asm = have_arm_ne10
+if (intrinsics_support.length() + asm_optimization.length() + inline_optimization.length()) > 0
+  have_arm_intrinsics_or_asm = true
+endif
+
 if host_cpu_family in ['arm', 'aarch64'] and have_arm_intrinsics_or_asm
   if opus_conf.has('OPUS_HAVE_RTCD')
     silk_sources +=  sources['SILK_SOURCES_ARM_RTCD']


### PR DESCRIPTION
Was getting the following error when building for arm64:
> silk/meson.build:33:3: ERROR: Unknown variable "have_arm_intrinsics_or_asm".

The variable definition in this commit is just copied from celt/meson.build.