### PR TITLE
meson: Install pkgconfig's pc file in correct path on FreeBSD

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -597,7 +597,11 @@ pkgconf.set('VERSION', opus_version)
 pkgconf.set('PC_BUILD', pc_build)
 pkgconf.set('LIBM', libm.found() ? '-lm' : '')
 
-pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
+if (host_machine.system() == 'freebsd')
+  pkg_install_dir = '@0@/pkgconfig'.format('libdata')
+else
+  pkg_install_dir = '@0@/pkgconfig'.format(get_option('libdir'))
+endif
 
 configure_file(input : 'opus.pc.in',
   output : 'opus.pc',


### PR DESCRIPTION
The builtin function automatically sets correct install path but since we're working around it we need to make sure manually