### PR TITLE
Fix various typos

### DIFF
--- a/cmake/OpusFunctions.cmake
+++ b/cmake/OpusFunctions.cmake
@@ -215,7 +215,7 @@ function(get_opus_sources SOURCE_GROUP MAKE_FILE SOURCES)
   if(${list_length} LESS 1)
     message(
       FATAL_ERROR
-        "No files parsed succesfully from ${SOURCE_GROUP} in ${MAKE_FILE}")
+        "No files parsed successfully from ${SOURCE_GROUP} in ${MAKE_FILE}")
   endif()
 
   # remove trailing whitespaces

--- a/doc/draft-ietf-codec-opus.xml
+++ b/doc/draft-ietf-codec-opus.xml
@@ -397,7 +397,7 @@ implementation can add or modify these control parameters without affecting inte
 important encoder control parameters in the reference encoder are listed below.
 </t>
 
-<section title="Bitrate" toc="exlcude">
+<section title="Bitrate" toc="exclude">
 <t>
 Opus supports all bitrates from 6&nbsp;kb/s to 510&nbsp;kb/s. All other parameters being
 equal, higher bitrate results in higher quality. For a frame size of 20&nbsp;ms, these
@@ -412,7 +412,7 @@ are the bitrate "sweet spots" for Opus in various configurations:
 </t>
 </section>
 
-<section title="Number of Channels (Mono/Stereo)" toc="exlcude">
+<section title="Number of Channels (Mono/Stereo)" toc="exclude">
 <t>
 Opus can transmit either mono or stereo frames within a single stream.
 When decoding a mono frame in a stereo decoder, the left and right channels are
@@ -426,7 +426,7 @@ The number of channels encoded can be selected in real-time, but by default the
 </t>
 </section>
 
-<section title="Audio Bandwidth" toc="exlcude">
+<section title="Audio Bandwidth" toc="exclude">
 <t>
 The audio bandwidths supported by Opus are listed in
  <xref target="audio-bandwidth"/>.
@@ -445,7 +445,7 @@ The audio bandwidth can be explicitly specified in real-time, but by default
 </section>
 
 
-<section title="Frame Duration" toc="exlcude">
+<section title="Frame Duration" toc="exclude">
 <t>
 Opus can encode frames of 2.5, 5, 10, 20, 40 or 60&nbsp;ms.
 It can also combine multiple frames into packets of up to 120&nbsp;ms.
@@ -459,7 +459,7 @@ For this reason, 20&nbsp;ms frames are a good choice for most applications.
 </t>
 </section>
 
-<section title="Complexity" toc="exlcude">
+<section title="Complexity" toc="exclude">
 <t>
 There are various aspects of the Opus encoding process where trade-offs
 can be made between CPU complexity and quality/bitrate. In the reference
@@ -477,7 +477,7 @@ resolution and the pitch post-filter.</t>
 </t>
 </section>
 
-<section title="Packet Loss Resilience" toc="exlcude">
+<section title="Packet Loss Resilience" toc="exclude">
 <t>
 Audio codecs often exploit inter-frame correlations to reduce the
 bitrate at a cost in error propagation: after losing one packet
@@ -488,7 +488,7 @@ choose a trade-off between bitrate and amount of error propagation.
 </t>
 </section>
 
-<section title="Forward Error Correction (FEC)" toc="exlcude">
+<section title="Forward Error Correction (FEC)" toc="exclude">
 <t>
    Another mechanism providing robustness against packet loss is the in-band
    Forward Error Correction (FEC).  Packets that are determined to
@@ -498,7 +498,7 @@ choose a trade-off between bitrate and amount of error propagation.
 </t>
 </section>
 
-<section title="Constant/Variable Bitrate" toc="exlcude">
+<section title="Constant/Variable Bitrate" toc="exclude">
 <t>
 Opus is more efficient when operating with variable bitrate (VBR), which is
 the default. However, in some (rare) applications, constant bitrate (CBR)
@@ -517,7 +517,7 @@ CBR due to the bit reservoir).
 </t>
 </section>
 
-<section title="Discontinuous Transmission (DTX)" toc="exlcude">
+<section title="Discontinuous Transmission (DTX)" toc="exclude">
 <t>
    Discontinuous Transmission (DTX) reduces the bitrate during silence
    or background noise.  When DTX is enabled, only one frame is encoded

--- a/doc/opus_in_isobmff.html
+++ b/doc/opus_in_isobmff.html
@@ -137,7 +137,7 @@ Table of Contents
         4.3.2 Opus Specific Box<a name="4.3.2"></a>
             Exactly one Opus Specific Box shall be present in each OpusSampleEntry.
             The Opus Specific Box contains an OpusDecoderConfigurationRecord which contains the Version field and
-            this specification defines version 0 of this record. If incompatible changes occured in the fields after
+            this specification defines version 0 of this record. If incompatible changes occurred in the fields after
             the Version field within the OpusDecoderConfigurationRecord in the future versions of this specification,
             another version will be defined.
             This box refers to Ogg Opus [3] at many parts but all the data are stored as big-endian format.
@@ -597,7 +597,7 @@ Table of Contents
                                             CoupledCount = 2
                                             ChannelMapping
                                                 0 -> 0: front left
-                                                1 -> 4: fron center
+                                                1 -> 4: front center
                                                 2 -> 1: front right
                                                 3 -> 2: side left
                                                 4 -> 3: side right

--- a/doc/release.txt
+++ b/doc/release.txt
@@ -21,7 +21,7 @@
   and update the links.
 - Update /topic in #opus IRC channel.
 
-Releases are commited to https://svn.xiph.org/releases/opus/
+Releases are committed to https://svn.xiph.org/releases/opus/
 which propagates to downloads.xiph.org, and copied manually
 to https://archive.mozilla.org/pub/opus/
 

--- a/include/opus.h
+++ b/include/opus.h
@@ -103,7 +103,7 @@ extern "C" {
   * @endcode
   *
   * where opus_encoder_get_size() returns the required size for the encoder state. Note that
-  * future versions of this code may change the size, so no assuptions should be made about it.
+  * future versions of this code may change the size, so no assumptions should be made about it.
   *
   * The encoder state is always continuous in memory and only a shallow copy is sufficient
   * to copy it (e.g. memcpy())
@@ -357,7 +357,7 @@ OPUS_EXPORT int opus_encoder_ctl(OpusEncoder *st, int request, ...) OPUS_ARG_NON
   * error = opus_decoder_init(dec, Fs, channels);
   * @endcode
   * where opus_decoder_get_size() returns the required size for the decoder state. Note that
-  * future versions of this code may change the size, so no assuptions should be made about it.
+  * future versions of this code may change the size, so no assumptions should be made about it.
   *
   * The decoder state is always continuous in memory and only a shallow copy is sufficient
   * to copy it (e.g. memcpy())

--- a/include/opus_multistream.h
+++ b/include/opus_multistream.h
@@ -143,7 +143,7 @@ extern "C" {
   * <a href="https://www.xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-810004.3.9">Vorbis
   * channel ordering</a>. A decoder may wish to apply an additional permutation
   * to the mapping the encoder used to achieve a different output channel
-  * order (e.g. for outputing in WAV order).
+  * order (e.g. for outputting in WAV order).
   *
   * Each multistream packet contains an Opus packet for each stream, and all of
   * the Opus packets in a single multistream packet must have the same

--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -1611,7 +1611,7 @@ opus_int32 opus_encode_native(OpusEncoder *st, const opus_val16 *pcm, int frame_
        redundancy = 1;
        celt_to_silk = 1;
        st->silk_bw_switch = 0;
-       /* Do a prefill without reseting the sampling rate control. */
+       /* Do a prefill without resetting the sampling rate control. */
        prefill=2;
     }
 


### PR DESCRIPTION
Found using `codespell -q 3 -L caf,highe,inlin,nd,ordert,shft`