### PR TITLE
dump_modes: add missing file to build

### DIFF
--- a/celt/dump_modes/Makefile
+++ b/celt/dump_modes/Makefile
@@ -11,6 +11,7 @@ SOURCES = dump_modes.c \
           ../entdec.c \
           ../mathops.c \
           ../mdct.c \
+          ../celt.c \
           ../kiss_fft.c
 
 ifdef HAVE_ARM_NE10


### PR DESCRIPTION
The file is required to build dump_modes correctly, because it defines `celt_assert`.