### PR TITLE
fix arm asm meson source build

### DIFF
--- a/celt/arm/meson.build
+++ b/celt/arm/meson.build
@@ -1,0 +1,12 @@
+arm2gnu = [find_program('arm2gnu.pl')] + arm2gnu_args
+celt_sources_arm_asm = configure_file(input: 'celt_pitch_xcorr_arm.s',
+  output: '@BASENAME@-gnu.S',
+  command: arm2gnu + ['@INPUT@'],
+  capture: true)
+celt_arm_armopts_s_in = configure_file(input: 'armopts.s.in',
+  output: 'armopts.s',
+  configuration: opus_conf)
+celt_arm_armopts_s = configure_file(input: [celt_arm_armopts_s_in],
+  output: '@BASENAME@-gnu.S',
+  command: arm2gnu + ['@INPUT@'],
+  capture: true)

--- a/celt/meson.build
+++ b/celt/meson.build
@@ -43,14 +43,7 @@ if host_cpu_family in ['arm', 'aarch64'] and have_arm_intrinsics_or_asm
     celt_sources += sources['CELT_SOURCES_ARM_NE10']
   endif
   if opus_arm_external_asm
-    arm2gnu = [find_program('arm/arm2gnu.pl')] + arm2gnu_args
-    celt_sources_arm_asm = configure_file(input: 'arm/celt_pitch_xcorr_arm.s',
-      output: '@BASENAME@-gnu.S',
-      command: arm2gnu + ['@INPUT@'],
-      capture: true)
-    celt_arm_armopts_s = configure_file(input: 'arm/armopts.s.in',
-      output: 'arm/armopts.s',
-      configuration: opus_conf)
+    subdir('arm')
     celt_static_libs += static_library('celt-armasm',
       celt_arm_armopts_s, celt_sources_arm_asm,
       install: false)

--- a/meson.build
+++ b/meson.build
@@ -277,17 +277,17 @@ if not opt_asm.disabled()
         if not opus_arm_may_have_edsp
           message('Trying to force-enable armv5e EDSP instructions...')
           # AS_ASM_ARM_EDSP_FORCE
-          opus_arm_may_have_edsp = cc.compiles(asm_tmpl.format('.arch armv5te\n.object_arch armv4t\nqadd r3,r3,r3'),
+          opus_arm_may_have_edsp = cc.compiles(asm_tmpl.format('.arch armv5te;.object_arch armv4t;qadd r3,r3,r3'),
                                                name : 'Assembler supports EDSP instructions on ARM (forced)')
         endif
         if not opus_arm_may_have_media
           message('Trying to force-enable ARMv6 media instructions...')
-          opus_arm_may_have_media = cc.compiles(asm_tmpl.format('.arch armv6\n.object_arch armv4t\nshadd8 r3,r3,r3'),
+          opus_arm_may_have_media = cc.compiles(asm_tmpl.format('.arch armv6;.object_arch armv4t;shadd8 r3,r3,r3'),
                                                 name : 'Assembler supports ARMv6 media instructions on ARM (forced)')
         endif
         if not opus_arm_may_have_neon
           message('Trying to force-enable NEON instructions...')
-          opus_arm_may_have_neon = cc.compiles(asm_tmpl.format('.arch armv7-a\n.fpu neon\n.object_arch armv4t\nvorr d0,d0,d0'),
+          opus_arm_may_have_neon = cc.compiles(asm_tmpl.format('.arch armv7-a;.fpu neon;.object_arch armv4t;vorr d0,d0,d0'),
                                                name : 'Assembler supports NEON instructions on ARM (forced)')
         endif
       endif

--- a/meson.build
+++ b/meson.build
@@ -252,6 +252,13 @@ if not opt_asm.disabled()
         opus_conf.set('OPUS_ARM_INLINE_NEON', 1)
         inline_optimization += ['NEON']
       endif
+
+      # AS_ASM_ARM_DOTPROD
+      if cc.compiles(asm_tmpl.format('udot v0.4s,v1.16b,v2.16b'),
+                     name : 'assembler supports DOTPROD instructions on ARM')
+        opus_conf.set('OPUS_ARM_INLINE_DOTPROD', 1)
+        inline_optimization += ['DOTPROD']
+      endif
     endif
 
     # We need Perl to translate RVCT-syntax asm to gas syntax
@@ -272,6 +279,9 @@ if not opt_asm.disabled()
 
       opus_arm_may_have_neon = opus_conf.has('OPUS_ARM_INLINE_NEON')
       opus_arm_presume_neon = opus_arm_may_have_neon and opus_can_presume_simd
+
+      opus_arm_may_have_dotprod = opus_conf.has('OPUS_ARM_INLINE_DOTPROD')
+      opus_arm_presume_dotprod = opus_arm_may_have_dotprod and opus_can_presume_simd
 
       if not opt_rtcd.disabled()
         if not opus_arm_may_have_edsp

--- a/meson.build
+++ b/meson.build
@@ -227,7 +227,7 @@ if not opt_asm.disabled()
                       #error GCC before 3.4 has critical bugs compiling inline assembly
                       #endif
                       #endif
-                      __asm__ (""::)''',
+                      int main(int argc, char ** argv) { __asm__ (""::); }''',
                    name : 'compiler supports gcc-style inline assembly')
 
       opus_conf.set('OPUS_ARM_INLINE_ASM', 1)


### PR DESCRIPTION
meson does mot support output with paths; add a meson.build file in the arm directory. The output files were being incorrectly placed in the celt/ directory.

Program arm/arm2gnu.pl found: YES (/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/build/opus-v1.5.1/celt/arm/arm2gnu.pl) Configuring celt_pitch_xcorr_arm-gnu.S with command

../celt/meson.build:51:25: ERROR: configure_file keyword argument "output" Output 'arm/armopts.s' must not contain a path segment.

before:
celt/celt_pitch_xcorr_arm-gnu.S

after:
celt/arm/celt_pitch_xcorr_arm-gnu.S
celt/arm/armopts.s
celt/arm/armopts-gnu.S

—-

this patch whilst fixing the meson build failure during the creation of source files and allowing the meson build to progress - still fails on an assembly error.

```
Program perl found: YES (/usr/bin/perl)
Message: Trying to force-enable armv5e EDSP instructions...
Checking if "Assembler supports EDSP instructions on ARM (forced)" compiles: NO 
Message: Trying to force-enable ARMv6 media instructions...
Checking if "Assembler supports ARMv6 media instructions on ARM (forced)" compiles: NO 
Message: Trying to force-enable NEON instructions...
Checking if "Assembler supports NEON instructions on ARM (forced)" compiles: NO 
Fetching value of define "__APPLE__" : (undefined) 
Checking if "compiler supports ARMv7/AArch64 NEON intrinsics" : links: YES 
Checking if "compiler supports AArch64 NEON intrinsics" : links: NO 
Checking if "compiler supports AArch64 NEON intrinsics with -mfpu=neon" : links: NO 
Message: Compiler does not support AArch64 NEON intrinsics
Checking if "compiler supports AArch64 DOTPROD intrinsics" : links: NO 
Checking if "compiler supports AArch64 DOTPROD intrinsics with -march=armv8.2-a+dotprod" : links: NO 
Message: Compiler does not support AArch64 DOTPROD intrinsics
Program arm2gnu.pl found: YES (/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/build/opus-v1.5.1/celt/arm/arm2gnu.pl)
Configuring celt_pitch_xcorr_arm-gnu.S with command
Configuring armopts.s using configuration
../celt/arm/meson.build:6: WARNING: The variable(s) 'OPUS_ARM_MAY_HAVE_EDSP', 'OPUS_ARM_MAY_HAVE_MEDIA', 'OPUS_ARM_MAY_HAVE_NEON' in the input file 'celt/arm/armopts.s.in' are not present in the given configuration data.
Configuring armopts-gnu.S with command
Configuring config.h using configuration
Configuring opus.pc using configuration
Program doxygen skipped: feature docs disabled
Build targets in project: 7

opus 1.4-git-v1.5.1

  Compiler support
    C99 var arrays                 : YES
    C99 lrintf                     : YES
    Use alloca                     : NO (using C99 variable-size arrays instead)

  Optimizations
    Floating point support         : NO
    Fast float approximations      : NO
    Fixed point debugging          : NO
    Inline assembly optimizations  : none
    External assembly optimizations: none
    Intrinsics optimizations       : ARMv7/AArch64 NEON
    Run-time CPU detection         : not needed

  General configuration
    Custom modes                   : NO
    Assertions                     : NO
    Hardening                      : YES
    Fuzzing                        : NO
    Check ASM                      : NO
    API documentation              : NO
    Extra programs                 : NO
    Tests                          : NO

  User defined options
    Cross files                    : /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/build/opus-v1.5.1/.armv7ve-libreelec-linux-gnueabihf/meson.conf
    bindir                         : /usr/bin
    buildtype                      : plain
    default_library                : static
    libdir                         : /usr/lib
    libexecdir                     : /usr/lib
    localstatedir                  : /var
    prefix                         : /usr
    sbindir                        : /usr/sbin
    strip                          : true
    sysconfdir                     : /etc
    docs                           : disabled
    extra-programs                 : disabled
    fixed-point                    : true
    tests                          : disabled

Found ninja-1.11.1 at /var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/toolchain/bin/ninja
Executing (target): ninja 
[1/149] Compiling C object celt/libcelt-armasm.a.p/meson-generated_.._arm_armopts-gnu.S.o
FAILED: celt/libcelt-armasm.a.p/meson-generated_.._arm_armopts-gnu.S.o 
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/toolchain/bin/armv7ve-libreelec-linux-gnueabihf-gcc -Icelt/libcelt-armasm.a.p -Icelt -I../celt -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -DOPUS_BUILD -DHAVE_CONFIG_H -fvisibility=hidden -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -fstack-protector-strong -march=armv7ve -mtune=cortex-a7 -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mfloat-abi=hard -mfpu=neon-vfpv4 -Wall -pipe -O2 -fomit-frame-pointer -DNDEBUG -fPIC -DPIC -fPIC -MD -MQ celt/libcelt-armasm.a.p/meson-generated_.._arm_armopts-gnu.S.o -MF celt/libcelt-armasm.a.p/meson-generated_.._arm_armopts-gnu.S.o.d -o celt/libcelt-armasm.a.p/meson-generated_.._arm_armopts-gnu.S.o -c celt/arm/armopts-gnu.S
celt/arm/armopts-gnu.S: Assembler messages:
celt/arm/armopts-gnu.S:30: Error: missing expression
celt/arm/armopts-gnu.S:33: Error: missing expression
celt/arm/armopts-gnu.S:36: Error: missing expression
[2/149] Compiling C object celt/libcelt-armasm.a.p/meson-generated_.._arm_celt_pitch_xcorr_arm-gnu.S.o
FAILED: celt/libcelt-armasm.a.p/meson-generated_.._arm_celt_pitch_xcorr_arm-gnu.S.o 
/var/media/DATA/home-rudi/LibreELEC.kernel11/build.LibreELEC-H3.arm-12.0-devel/toolchain/bin/armv7ve-libreelec-linux-gnueabihf-gcc -Icelt/libcelt-armasm.a.p -Icelt -I../celt -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -DOPUS_BUILD -DHAVE_CONFIG_H -fvisibility=hidden -Wcast-align -Wnested-externs -Wshadow -Wstrict-prototypes -fstack-protector-strong -march=armv7ve -mtune=cortex-a7 -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mfloat-abi=hard -mfpu=neon-vfpv4 -Wall -pipe -O2 -fomit-frame-pointer -DNDEBUG -fPIC -DPIC -fPIC -MD -MQ celt/libcelt-armasm.a.p/meson-generated_.._arm_celt_pitch_xcorr_arm-gnu.S.o -MF celt/libcelt-armasm.a.p/meson-generated_.._arm_celt_pitch_xcorr_arm-gnu.S.o.d -o celt/libcelt-armasm.a.p/meson-generated_.._arm_celt_pitch_xcorr_arm-gnu.S.o -c celt/arm/celt_pitch_xcorr_arm-gnu.S
celt/arm/armopts-gnu.S: Assembler messages:
celt/arm/armopts-gnu.S:30: Error: missing expression
celt/arm/armopts-gnu.S:33: Error: missing expression
celt/arm/armopts-gnu.S:36: Error: missing expression
[16/149] Compiling C object celt/libopus-celt.a.p/celt_encoder.c.o
ninja: build stopped: subcommand failed.
```
- Fixes #295
- Fixes #316 
