### PR TITLE
Only run legacy appveyor ci on github master branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,10 @@ platform:
 - Win32
 - x64
 
+branches:
+  only:
+    - master
+
 environment:
   api_key:
     secure: kR3Ac0NjGwFnTmXdFrR8d6VXjdk5F7L4F/BilC4nvaM=


### PR DESCRIPTION
@jmvalin 

Currently the legacy appveyor CI on master runs against all branches including main on github. This causes CI to look that it is failing. See screenshot below.

![image](https://github.com/xiph/opus/assets/302709/90d19a9c-4baa-456d-9360-cf42f94ef6d7)

The fix is to limit appveyor CI to only run on master branch in Github and no other.

So this patch need to be applied to "master" branch not main branch.