### PR TITLE
Fix type mismatch in opus_packet_extensions_generate.

### DIFF
--- a/src/opus_private.h
+++ b/src/opus_private.h
@@ -214,7 +214,7 @@ int opus_multistream_decode_native(
 
 opus_int32 opus_packet_extensions_parse(const unsigned char *data, opus_int32 len, opus_extension_data *extensions, opus_int32 *nb_extensions);
 
-opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, int nb_extensions, int pad);
+opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, opus_int32 nb_extensions, int pad);
 
 opus_int32 opus_packet_extensions_count(const unsigned char *data, opus_int32 len);
 

--- a/src/repacketizer.c
+++ b/src/repacketizer.c
@@ -155,7 +155,8 @@ opus_int32 opus_repacketizer_out_range_impl(OpusRepacketizer *rp, int begin, int
    /* incorporate any extensions from the repacketizer padding */
    for (i=begin;i<end;i++)
    {
-      int frame_ext_count, j;
+      opus_int32 frame_ext_count;
+      int j;
       frame_ext_count = total_ext_count - ext_count;
       int ret = opus_packet_extensions_parse(rp->paddings[i], rp->padding_len[i],
          &all_extensions[ext_count], &frame_ext_count);


### PR DESCRIPTION
Changed type of nb_extensions from int to opus_int32.

----

On a few platforms int is not the same as int32_t. Got this build failure while cross-compiling for the Nintendo 3DS (using devkitPro homebrew SDK):

This matches now the signature in src/extensions.c

```
opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, opus_int32 nb_extensions, int pad)
``` 

---

Here the error message I got:

```
src/extensions.c:186:12: error: conflicting types for 'opus_packet_extensions_generate'; have 'opus_int32(unsigned char *, opus_int32,  const opus_extension_data *, opus_int32,  int)' {aka 'long int(unsigned char *, long int,  const opus_extension_data *, long int,  int)'}
  186 | opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, opus_int32 nb_extensions, int pad)
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from src/extensions.c:36:
src/opus_private.h:217:12: note: previous declaration of 'opus_packet_extensions_generate' with type 'opus_int32(unsigned char *, opus_int32,  const opus_extension_data *, int,  int)' {aka 'long int(unsigned char *, long int,  const opus_extension_data *, int,  int)'}
  217 | opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, int nb_extensions, int pad);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [Makefile:3390: src/extensions.lo] Fehler 1
```

---

Also fixed this warning:

```
src/repacketizer.c: In function 'opus_repacketizer_out_range_impl':
src/repacketizer.c:161:38: warning: passing argument 4 of 'opus_packet_extensions_parse' from incompatible pointer type [-Wincompatible-pointer-types]
  161 |          &all_extensions[ext_count], &frame_ext_count);
      |                                      ^~~~~~~~~~~~~~~~
      |                                      |
      |                                      int *
In file included from src/repacketizer.c:33:
src/opus_private.h:215:129: note: expected 'opus_int32 *' {aka 'long int *'} but argument is of type 'int *'
  215 | opus_int32 opus_packet_extensions_parse(const unsigned char *data, opus_int32 len, opus_extension_data *extensions, opus_int32 *nb_extensions);   |                                                                                                         
```