### PR TITLE
Update CMake to 3.16 and add OPUS_STATIC_RUNTIME option

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   CMakeVersionTest:
-    name: Test build with CMake 3.1.0
+    name: Test build with CMake 3.16.0
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -12,9 +12,9 @@ jobs:
           fetch-depth: 0
       - name: Download models
         run: ./autogen.sh
-      - name: Install CMake 3.1
+      - name: Install CMake 3.16
         run: |
-          curl -sL https://github.com/Kitware/CMake/releases/download/v3.1.0/cmake-3.1.0-Linux-x86_64.sh -o cmakeinstall.sh
+          curl -sL https://github.com/Kitware/CMake/releases/download/v3.16.0/cmake-3.16.0-Linux-x86_64.sh -o cmakeinstall.sh
           chmod +x cmakeinstall.sh
           sudo ./cmakeinstall.sh --prefix=/usr/local --exclude-subdir
           rm cmakeinstall.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.16)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 include(OpusPackageVersion)
@@ -95,6 +95,12 @@ if(APPLE)
   set(OPUS_BUILD_FRAMEWORK_HELP_STR "build Framework bundle for Apple systems.")
   option(OPUS_BUILD_FRAMEWORK ${OPUS_BUILD_FRAMEWORK_HELP_STR} OFF)
   add_feature_info(OPUS_BUILD_FRAMEWORK OPUS_BUILD_FRAMEWORK ${OPUS_BUILD_FRAMEWORK_HELP_STR})
+endif()
+
+if(MSVC)
+  set(OPUS_STATIC_RUNTIME_HELP_STR "build with static runtime library.")
+  option(OPUS_STATIC_RUNTIME ${OPUS_STATIC_RUNTIME_HELP_STR} OFF)
+  add_feature_info(OPUS_STATIC_RUNTIME OPUS_STATIC_RUNTIME ${OPUS_STATIC_RUNTIME_HELP_STR})
 endif()
 
 set(OPUS_FIXED_POINT_DEBUG_HELP_STR "debug fixed-point implementation.")
@@ -263,6 +269,14 @@ set(Opus_PUBLIC_HEADER
 
 if(OPUS_CUSTOM_MODES)
   list(APPEND Opus_PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/opus_custom.h)
+endif()
+
+if(MSVC)
+  if(OPUS_STATIC_RUNTIME)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+  endif()
 endif()
 
 add_library(opus ${opus_headers} ${opus_sources} ${opus_sources_float} ${Opus_PUBLIC_HEADER})


### PR DESCRIPTION
This resolves issue #333 by:
- Updating CMake to 3.16 as recommended in the issue discussions
- Adding the OPUS_STATIC_RUNTIME option when using MSVC
- Updating the CMake CI action to use 3.16