### PR TITLE
Fix type mismatch in opus_multistream_decode_native

### DIFF
--- a/src/opus_private.h
+++ b/src/opus_private.h
@@ -214,7 +214,7 @@ int opus_multistream_decode_native(
 
 opus_int32 opus_packet_extensions_parse(const unsigned char *data, opus_int32 len, opus_extension_data *extensions, opus_int32 *nb_extensions);
 
-opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, int nb_extensions, int pad);
+opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len, const opus_extension_data  *extensions, opus_int32 nb_extensions, int pad);
 
 opus_int32 opus_packet_extensions_count(const unsigned char *data, opus_int32 len);
 


### PR DESCRIPTION
The type of the nb_extensions argument to opus_multistream_decode_native() in the header does not match the implementation. It is defined as (opus_int32) in the C, and (int) in the H.
On some embedded platforms, opus_int32 is not defined as an int type. It may be long int, or other. This causes a compilation failure due to mismatched types.

This PR changes the type in the header to match the implementation to remove this compilation failure.

Bug identified on the ESP32 platform.