### PR TITLE
Fix opus_demo lossgen when using weights file

### DIFF
--- a/dnn/write_lpcnet_weights.c
+++ b/dnn/write_lpcnet_weights.c
@@ -50,6 +50,9 @@
 #include "lace_data.c"
 #include "nolace_data.c"
 #endif
+#ifdef ENABLE_LOSSGEN
+#include "lossgen_data.c"
+#endif
 
 void write_weights(const WeightArray *list, FILE *fout)
 {
@@ -91,6 +94,9 @@ int main(void)
 #ifndef DISABLE_NOLACE
   write_weights(nolacelayers_arrays, fout);
 #endif
+#endif
+#ifdef ENABLE_LOSSGEN
+  write_weights(lossgen_arrays, fout);
 #endif
   fclose(fout);
   return 0;

--- a/src/opus_demo.c
+++ b/src/opus_demo.c
@@ -810,6 +810,9 @@ int main(int argc, char *argv[])
     if (enc) opus_encoder_ctl(enc, OPUS_SET_DNN_BLOB(blob_data, blob_len));
     if (dec) opus_decoder_ctl(dec, OPUS_SET_DNN_BLOB(blob_data, blob_len));
     if (dred_dec) opus_dred_decoder_ctl(dred_dec, OPUS_SET_DNN_BLOB(blob_data, blob_len));
+#ifdef ENABLE_LOSSGEN
+    lossgen_load_model(&lossgen, blob_data, blob_len);
+#endif
 #endif
     while (!stop)
     {


### PR DESCRIPTION
When trying to test `opus_demo` with both `USE_WEIGHTS_FILE` and `ENABLE_LOSSGEN`, it does not work. The "loss generator" data is invalid and therefore does not apply the loss.

This PR adds the lossgen data to the lpcnet weights file and loads it when running the `opus_demo`, when needed.

