### PR TITLE
Fix SIMD fallback code when AVX2 is not available 

### DIFF
--- a/dnn/vec_avx.h
+++ b/dnn/vec_avx.h
@@ -168,8 +168,8 @@ typedef struct {
   __m128i lo;
   __m128i hi;
 } mm256i_emu;
-typedef __m256i real_m256i;
 #define __m256i mm256i_emu
+typedef __m256i real_m256i;
 
 static inline mm256i_emu mm256_setzero_si256(void) {
   mm256i_emu ret;


### PR DESCRIPTION
Same as https://github.com/xiph/rnnoise/pull/228

Currently the code first typedefs a fallback type based on __m256i and only on the following line it actually defines __m256i as the emulated type. This needs to be the other way around! This fixes building opus on emscripten with vectorization enabled.