### PR TITLE
add celt/arm/meson.build to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -353,6 +353,7 @@ EXTRA_DIST = opus.pc.in \
              tests/meson.build \
              doc/meson.build \
              tests/run_vectors.sh \
+             celt/arm/meson.build \
              celt/arm/arm2gnu.pl \
              celt/arm/celt_pitch_xcorr_arm.s
 


### PR DESCRIPTION
Otherwise, it is missing in the release tarball and building with meson on ARM fails with:

.../celt/meson.build:46:4: ERROR: Nonexistent build file 'celt/arm/meson.build'