### PR TITLE
Support OPUS_SET_COMPLEXITY() for multistream decoder

### DIFF
--- a/src/opus_multistream_decoder.c
+++ b/src/opus_multistream_decoder.c
@@ -433,6 +433,7 @@ int opus_multistream_decoder_ctl_va_list(OpusMSDecoder *st, int request,
        case OPUS_GET_GAIN_REQUEST:
        case OPUS_GET_LAST_PACKET_DURATION_REQUEST:
        case OPUS_GET_PHASE_INVERSION_DISABLED_REQUEST:
+       case OPUS_GET_COMPLEXITY_REQUEST:
        {
           OpusDecoder *dec;
           /* For int32* GET params, just query the first stream */
@@ -507,6 +508,7 @@ int opus_multistream_decoder_ctl_va_list(OpusMSDecoder *st, int request,
        }
        break;
        case OPUS_SET_GAIN_REQUEST:
+       case OPUS_SET_COMPLEXITY_REQUEST:
        case OPUS_SET_PHASE_INVERSION_DISABLED_REQUEST:
        {
           int s;


### PR DESCRIPTION
OPUS_SET_COMPLEXITY() is already implemented in the decoder for controlling deep PLC since commit
8d43b185b2bb44841cb9b13e6dc1f4f30da0db87

This commit makes it also available for the mulitstream decoder.