### PR TITLE
Fix warning for static vs non-static declaration/definitions

### DIFF
--- a/celt/celt_decoder.c
+++ b/celt/celt_decoder.c
@@ -166,7 +166,7 @@ int celt_decoder_get_size(int channels)
    return opus_custom_decoder_get_size(mode, channels);
 }
 
-OPUS_CUSTOM_NOSTATIC int opus_custom_decoder_get_size(const CELTMode *mode, int channels)
+int opus_custom_decoder_get_size(const CELTMode *mode, int channels)
 {
    int size = sizeof(struct CELTDecoder)
             + (channels*(DECODE_BUFFER_SIZE+mode->overlap)-1)*sizeof(celt_sig)
@@ -205,7 +205,7 @@ int celt_decoder_init(CELTDecoder *st, opus_int32 sampling_rate, int channels)
       return OPUS_OK;
 }
 
-OPUS_CUSTOM_NOSTATIC int opus_custom_decoder_init(CELTDecoder *st, const CELTMode *mode, int channels)
+int opus_custom_decoder_init(CELTDecoder *st, const CELTMode *mode, int channels)
 {
    if (channels < 0 || channels > 2)
       return OPUS_BAD_ARG;

--- a/celt/celt_encoder.c
+++ b/celt/celt_encoder.c
@@ -133,7 +133,7 @@ int celt_encoder_get_size(int channels)
    return opus_custom_encoder_get_size(mode, channels);
 }
 
-OPUS_CUSTOM_NOSTATIC int opus_custom_encoder_get_size(const CELTMode *mode, int channels)
+int opus_custom_encoder_get_size(const CELTMode *mode, int channels)
 {
    int size = sizeof(struct CELTEncoder)
          + (channels*mode->overlap-1)*sizeof(celt_sig)    /* celt_sig in_mem[channels*mode->overlap]; */


### PR DESCRIPTION
In include/opus_custom.h these are declared as OPUS_CUSTOM_EXPORT_STATIC