### PR TITLE
[Docs] Clarify return value for decode() functions

### DIFF
--- a/include/opus.h
+++ b/include/opus.h
@@ -472,7 +472,7 @@ OPUS_EXPORT int opus_decoder_init(
   *  FEC cases, frame_size <b>must</b> be a multiple of 2.5 ms.
   * @param [in] decode_fec <tt>int</tt>: Flag (0 or 1) to request that any in-band forward error correction data be
   *  decoded. If no such data is available, the frame is decoded as if it were lost.
-  * @returns Number of decoded samples or @ref opus_errorcodes
+  * @returns Number of decoded samples per channel or @ref opus_errorcodes
   */
 OPUS_EXPORT OPUS_WARN_UNUSED_RESULT int opus_decode(
     OpusDecoder *st,
@@ -497,7 +497,7 @@ OPUS_EXPORT OPUS_WARN_UNUSED_RESULT int opus_decode(
   *  FEC cases, frame_size <b>must</b> be a multiple of 2.5 ms.
   * @param [in] decode_fec <tt>int</tt>: Flag (0 or 1) to request that any in-band forward error correction data be
   *  decoded. If no such data is available the frame is decoded as if it were lost.
-  * @returns Number of decoded samples or @ref opus_errorcodes
+  * @returns Number of decoded samples per channel or @ref opus_errorcodes
   */
 OPUS_EXPORT OPUS_WARN_UNUSED_RESULT int opus_decode_float(
     OpusDecoder *st,


### PR DESCRIPTION
Although being explicitly mentioned in the opus_decoder group in documentation (like this https://opus-codec.org/docs/opus_api-1.5/group__opus__decoder.html#details), the actual functions documentation (`@returns` annotations) for `opus_decode()` and `opus_decode_float()` do not specify if the returned value is equal to amount of samples per channel, or samples of all channels combined (basically amount of elements in output pcm array). I've been integrating Opus and some other codecs into a project at once, and because of a bit different APIs, silently relied on inline functions documentation, and mistakenly assumed that returned amount of samples is both channels combined, resulting in wrong audio output and a bit of debugging :D. The fact that output PCM values are interleaved also contributed to that. So this PR just adds that small clarification to both of these functions.

Blame of not being an attentive documentation reader is still surely on me ;)