### PR TITLE
Update configure.ac， Fix avx2 detection error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -697,7 +697,7 @@ AS_IF([test x"$enable_intrinsics" = x"yes"],[
              __m256i mtest2;
              mtest = _mm256_set1_ps((float)time(NULL));
              mtest = _mm256_fmadd_ps(mtest, mtest, mtest);
-             mtest1 = _mm256_set_m128i(_mm_loadu_si64(utest), _mm_loadu_si64(utest));
+             mtest1 = _mm256_set_m128i(_mm_loadu_si128(utest), _mm_loadu_si128(utest));
              mtest2 =
               _mm256_cvtepi16_epi32(_mm_loadu_si128(utest));
              return _mm256_extract_epi16(_mm256_xor_si256(


### PR DESCRIPTION
config.log error info

configtest.c:39:40 error: incompatible type for argument 1 of '_mm256_set_m128i'
mtest = _mm256_set_m128i(_mm_loadu_si64(utest), _mm_loadu_si64(utest));
