### PR TITLE
add tar -z option

### DIFF
--- a/dnn/download_model.sh
+++ b/dnn/download_model.sh
@@ -27,4 +27,4 @@ fi
 
 
 
-tar xvomf $model
+tar xvzomf $model

--- a/tests/opus_build_test.sh
+++ b/tests/opus_build_test.sh
@@ -6,7 +6,7 @@ oldvectors=`realpath "$3"`
 newvectors=`realpath "$4"`
 base=`basename "$tarball" .tar.gz`
 
-tar xvf "$tarball" > /dev/null 2>&1
+tar xvzf "$tarball" > /dev/null 2>&1
 cd "$base"
 
 if [ $? -ne 0 ]


### PR DESCRIPTION
only GNU tar recognizes compressed file automatically.
please do not forget "-z" option with tar when handling .tar.gz file, for portability.
