### PR TITLE
Fix Windows compilation

### DIFF
--- a/src/opus_private.h
+++ b/src/opus_private.h
@@ -242,11 +242,11 @@ int opus_multistream_decode_native(
   void *user_data
 );
 
-opus_int32 opus_packet_extensions_parse(const unsigned char *data,
+OPUS_EXPORT opus_int32 opus_packet_extensions_parse(const unsigned char *data,
  opus_int32 len, opus_extension_data *extensions, opus_int32 *nb_extensions,
  int nb_frames);
 
-opus_int32 opus_packet_extensions_parse_ext(const unsigned char *data,
+OPUS_EXPORT opus_int32 opus_packet_extensions_parse_ext(const unsigned char *data,
  opus_int32 len, opus_extension_data *extensions, opus_int32 *nb_extensions,
  const opus_int32 *nb_frame_exts, int nb_frames);
 
@@ -254,7 +254,7 @@ opus_int32 opus_packet_extensions_generate(unsigned char *data, opus_int32 len,
  const opus_extension_data *extensions, opus_int32 nb_extensions,
  int nb_frames, int pad);
 
-opus_int32 opus_packet_extensions_count(const unsigned char *data,
+OPUS_EXPORT opus_int32 opus_packet_extensions_count(const unsigned char *data,
  opus_int32 len, int nb_frames);
 
 opus_int32 opus_packet_extensions_count_ext(const unsigned char *data,


### PR DESCRIPTION
```
libopus.lib(repacketizer.obj) : error LNK2001: unresolved external symbol opus_packet_extensions_count [D:\a\opus\opus\build\opus.vcxproj]
libopus.lib(repacketizer.obj) : error LNK2001: unresolved external symbol opus_packet_extensions_generate [D:\a\opus\opus\build\opus.vcxproj]
libopus.lib(repacketizer.obj) : error LNK2001: unresolved external symbol opus_packet_extensions_parse [D:\a\opus\opus\build\opus.vcxproj]
```