### PR TITLE
CMakeLists.txt - correction of the MSVC_CLANG_CL variable setting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@ include(CMakeDependentOption)
 include(FeatureSummary)
 
 # Detect clang-cl
-set(MSVC_CLANG_CL false BOOL)
+set(MSVC_CLANG_CL FALSE)
 if (MSVC)
     if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-        set(MSVC_CLANG_CL true BOOL)
+        set(MSVC_CLANG_CL TRUE)
     endif()
 endif()
 


### PR DESCRIPTION
At the moment, the
**if (MSVC_CLANG_CL)**
check always passes and as a result the "**-msse4.1**" flag is set when building via **MSVC**.