### PR TITLE
encoder: remove mandatory dc_reject filter

### DIFF
--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -1897,7 +1897,8 @@ static opus_int32 opus_encode_frame_native(OpusEncoder *st, const opus_res *pcm,
        }
 #endif
     } else {
-       dc_reject(pcm, 3, &pcm_buf[total_buffer*st->channels], st->hp_mem, frame_size, st->channels, st->Fs);
+       for (i=0;i<frame_size*st->channels;i++)
+          pcm_buf[total_buffer*st->channels + i] = pcm[i];
     }
 #ifndef FIXED_POINT
     if (float_api)


### PR DESCRIPTION
Restore this piece of code to before 0869829f343f85935fac22462d228a065d0ba320. The dc_reject itself is kept in the code, for possible future use.
Fixes #434 