### PR TITLE
Fix macOS framework builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -124,7 +124,13 @@ jobs:
             name: "MacOSX/Framework/X64/Release",
             os: macos-latest,
             config: Release,
-            args: -DBUILD_FRAMEWORK=ON -DCMAKE_INSTALL_PREFIX=install
+            args: -DOPUS_BUILD_FRAMEWORK=ON -DCMAKE_INSTALL_PREFIX=install -DBUILD_TESTING=ON -DCMAKE_OSX_ARCHITECTURES=x86_64
+          }
+        - {
+            name: "MacOSX/Framework/arm64/Release",
+            os: macos-latest,
+            config: Release,
+            args: -DOPUS_BUILD_FRAMEWORK=ON -DCMAKE_INSTALL_PREFIX=install -DBUILD_TESTING=ON -DCMAKE_OSX_ARCHITECTURES=arm64
           }
           # use unix makefiles for iOS to avoid Xcode to complain about signing.
         - {


### PR DESCRIPTION
This PR fixes 2 issues with CI builds of macOS framework:

1. Correct flag should be `OPUS_BUILD_FRAMEWORK`, not `BUILD_FRAMEWORK`.
2. Correct `CMAKE_OSX_ARCHITECTURES` should be set, otherwise host arch will be used.

P.S.

2 more thoughts:

1. I haven't checked myself, but iOS framework should also use `OPUS_BUILD_FRAMEWORK`, not `BUILD_FRAMEWORK`
2. `FRAMEWORK_VERSION` in cmake list should be probably set to "A" (major verison), not `${PROJECT_VERSION}`