### PR TITLE
meson: Fix harmless warning

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,7 +26,7 @@ foreach t : opus_tests
   if test_name == 'test_opus_projection' or test_name == 'test_opus_extensions'
     exe_kwargs = {
       'link_with': [celt_lib, silk_lib, dnn_lib],
-      'objects': opus_lib.extract_all_objects(),
+      'objects': opus_lib.extract_all_objects(recursive: true),
     }
   endif
 


### PR DESCRIPTION
For context on the warning:
https://mesonbuild.com/Release-notes-for-0-46-0.html#recursively-extract-objects

Rebase of https://github.com/xiph/opus/pull/285.