### PR TITLE
multistream: Add DRED duration CTL support

### DIFF
--- a/src/opus_multistream_encoder.c
+++ b/src/opus_multistream_encoder.c
@@ -1316,6 +1316,51 @@ int opus_multistream_encoder_ctl_va_list(OpusMSEncoder *st, int request,
        *value = st->variable_duration;
    }
    break;
+#ifdef ENABLE_DRED
+   case OPUS_SET_DRED_DURATION_REQUEST:
+   {
+      int s;
+      opus_int32 value = va_arg(ap, opus_int32);
+      for (s=0;s<st->layout.nb_streams;s++)
+      {
+         OpusEncoder *enc;
+         enc = (OpusEncoder*)ptr;
+         if (s < st->layout.nb_coupled_streams)
+            ptr += align(coupled_size);
+         else
+            ptr += align(mono_size);
+         ret = opus_encoder_ctl(enc, OPUS_SET_DRED_DURATION(value));
+         if (ret != OPUS_OK)
+            break;
+      }
+   }
+   break;
+   case OPUS_GET_DRED_DURATION_REQUEST:
+   {
+      int s;
+      opus_int32 *value = va_arg(ap, opus_int32*);
+      if (!value)
+      {
+         goto bad_arg;
+      }
+      for (s=0;s<st->layout.nb_streams;s++)
+      {
+         opus_int32 tmp;
+         OpusEncoder *enc;
+         enc = (OpusEncoder*)ptr;
+         if (s < st->layout.nb_coupled_streams)
+            ptr += align(coupled_size);
+         else
+            ptr += align(mono_size);
+         ret = opus_encoder_ctl(enc, OPUS_GET_DRED_DURATION(&tmp));
+         if (ret != OPUS_OK)
+            break;
+         if (s == 0)
+            *value = tmp;
+      }
+   }
+   break;
+#endif
    case OPUS_RESET_STATE:
    {
       int s;


### PR DESCRIPTION
## Summary
Forward `OPUS_SET_DRED_DURATION_REQUEST` and `OPUS_GET_DRED_DURATION_REQUEST` 
to all underlying encoders in the multistream encoder.

## Motivation
Currently, applications using `libopusenc` (Ogg Opus) or the multistream API 
cannot enable DRED because the CTL requests are not forwarded to the internal 
encoders. This patch fixes that gap.

## Testing
Verified in an iOS application using `libopusenc` -> `libopus` 1.5.2 with 
`--enable-dred`. After this patch, `OPUS_SET_DRED_DURATION()` returns `OPUS_OK` 
instead of `OPUS_UNIMPLEMENTED`.

## ‼️Note for Maintainers

This fix is particularly important for users of v1.5.2 who are already 
using DRED with multistream/Ogg encoding. 

Since jumping to v1.6 may be a larger commitment for some users, would 
it be appropriate to consider a v1.5.3 patch release that includes this 
fix? This would provide a safe upgrade path for users who want the bug 
fix without adopting new features.

**Related PR:** This fix works in conjunction with xiph/libopusenc#38, which forwards the DRED CTL requests from the `ope_encoder_ctl()` API to the multistream encoder.

Together, these two PRs complete the DRED control path for applications encoding Ogg Opus files:

```
Application
    ↓ ope_encoder_ctl(OPUS_SET_DRED_DURATION)
libopusenc (PR xiph/libopusenc#38)
    ↓ opus_multistream_encoder_ctl()
opus multistream (this PR)
    ↓ opus_encoder_ctl()
opus encoder (DRED enabled ✓)
```

Without both fixes, users cannot enable DRED when encoding via the standard Ogg Opus workflow.