### PR TITLE
meson: Fix empty options in celt armopts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -323,6 +323,8 @@ if not opt_asm.disabled()
         else
           rtcd_support += ['EDSP']
         endif
+      else
+        opus_conf.set('OPUS_ARM_MAY_HAVE_EDSP', 0)
       endif
       if opus_arm_may_have_media
         opus_conf.set('OPUS_ARM_MAY_HAVE_MEDIA', 1)
@@ -332,6 +334,8 @@ if not opt_asm.disabled()
         else
           rtcd_support += ['Media']
         endif
+      else
+        opus_conf.set('OPUS_ARM_MAY_HAVE_MEDIA', 0)
       endif
       if opus_arm_may_have_neon
         opus_conf.set('OPUS_ARM_MAY_HAVE_NEON', 1)
@@ -341,6 +345,8 @@ if not opt_asm.disabled()
         else
           rtcd_support += ['NEON']
         endif
+      else
+        opus_conf.set('OPUS_ARM_MAY_HAVE_NEON', 0)
       endif
       if opus_arm_may_have_dotprod
         opus_conf.set('OPUS_ARM_MAY_HAVE_DOTPROD', 1)


### PR DESCRIPTION
For example, if CPU does not support NEON, the armopts.s OPUS_ARM_MAY_HAVE_NEON should be set to 0. Without this fix, @OPUS_ARM_MAY_HAVE_NEON@ macro is replaced to "", which leads to failure during compilation when armopts-gnu.S is compiled by GCC.