### PR TITLE
cmake: define ENABLE_OSCE_BWE when OPUS_OSCE is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,7 @@ endif()
 
 if (OPUS_OSCE)
   add_sources_group(opus lpcnet ${osce_headers} ${osce_sources})
-  target_compile_definitions(opus PRIVATE ENABLE_OSCE)
+  target_compile_definitions(opus PRIVATE ENABLE_OSCE ENABLE_OSCE_BWE)
 endif()
 
 if(NOT OPUS_DISABLE_INTRINSICS)


### PR DESCRIPTION
This fixes compilation of the bandwidth extension module when compiling with cmake.

Matches the behaviour of `--enable-osce` from https://github.com/xiph/opus/blob/main/configure.ac#L966 which also ties the 2 options together.