### PR TITLE
Fix GCC 16 warnings in silk/float/pitch_analysis_core_FLP.c

### DIFF
--- a/silk/float/pitch_analysis_core_FLP.c
+++ b/silk/float/pitch_analysis_core_FLP.c
@@ -82,7 +82,7 @@ opus_int silk_pitch_analysis_core_FLP(      /* O    Voicing estimate: 0 voiced, 
     opus_int   i, k, d, j;
     silk_float frame_8kHz[  PE_MAX_FRAME_LENGTH_MS * 8 ];
     silk_float frame_4kHz[  PE_MAX_FRAME_LENGTH_MS * 4 ];
-    opus_int16 frame_8_FIX[ PE_MAX_FRAME_LENGTH_MS * 8 ];
+    opus_int16 frame_8_FIX[ PE_MAX_FRAME_LENGTH_MS * 8 ] = {0};
     opus_int16 frame_4_FIX[ PE_MAX_FRAME_LENGTH_MS * 4 ];
     opus_int32 filt_state[ 6 ];
     silk_float threshold, contour_bias;
@@ -165,7 +165,7 @@ opus_int silk_pitch_analysis_core_FLP(      /* O    Voicing estimate: 0 voiced, 
     /******************************************************************************
     * FIRST STAGE, operating in 4 khz
     ******************************************************************************/
-    silk_memset(C, 0, sizeof(silk_float) * nb_subfr * ((PE_MAX_LAG >> 1) + 5));
+    silk_memset(C, 0, sizeof(silk_float) * (size_t)nb_subfr * ((PE_MAX_LAG >> 1) + 5));
     target_ptr = &frame_4kHz[ silk_LSHIFT( sf_length_4kHz, 2 ) ];
     for( k = 0; k < nb_subfr >> 1; k++ ) {
         /* Check that we are within range of the array */


### PR DESCRIPTION
Fix two compiler warnings reported in #451 when building with GCC 16:

### 1. `-Wmaybe-uninitialized` for `frame_8_FIX`

GCC 16 cannot prove that `frame_8_FIX` is always initialized before use at line 157 (`silk_resampler_down2` call), even though all three branches of the `Fs_kHz` conditional (16, 12, 8) write to it before the common path reads it.

**Fix:** Zero-initialize the array at declaration. The cost is negligible — 640 bytes (`PE_MAX_FRAME_LENGTH_MS * 8 * sizeof(opus_int16)` = `40 * 8 * 2`), called once per pitch analysis invocation.

### 2. `-Wstringop-overflow` for `silk_memset` on `C[]`

The size expression `sizeof(silk_float) * nb_subfr * ((PE_MAX_LAG >> 1) + 5)` mixes `size_t` (from `sizeof`) with signed `opus_int` (`nb_subfr`). GCC 16's improved overflow analysis warns that the intermediate product could theoretically be negative and wrap to a huge value (`~UINT64_MAX`), exceeding the maximum object size.

**Fix:** Cast `nb_subfr` to `size_t` to make the arithmetic unambiguously unsigned. `nb_subfr` is always positive (validated by the caller and bounded by `PE_MAX_NB_SUBFR = 4`).

Fixes #451.