### PR TITLE
Fix compilation with ClangCL and AVX2

### DIFF
--- a/silk/x86/NSQ_del_dec_avx2.c
+++ b/silk/x86/NSQ_del_dec_avx2.c
@@ -71,7 +71,7 @@ static OPUS_INLINE int verify_assumptions(const silk_encoder_state *psEncC)
 }
 
 /* Intrinsics not defined on MSVC */
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #include <intsafe.h>
 static inline int __builtin_sadd_overflow(opus_int32 a, opus_int32 b, opus_int32* res)
 {


### PR DESCRIPTION
Both `__builtin_sadd_overflow()` and `__builtin_ctz()` are available in Clang even when building under Visual Studio, define them only when compiling with MSVC to fix the following error:

```
opus\silk\x86\NSQ_del_dec_avx2.c(81,19): warning : redeclaring non-static '__builtin_ctz' as static is a Microsoft extension [-Wmicrosoft-redeclare-static]
     81 | static inline int __builtin_ctz(unsigned int x)
        |                   ^
  C:\Program Files\LLVM\lib\clang\22\include\ia32intrin.h(43,10): note: '__builtin_ctz' is a builtin with type 'int (unsigned int)'
     43 |   return __builtin_ctz((unsigned int)__A);
        |          ^
opus\silk\x86\NSQ_del_dec_avx2.c(81,19): error : definition of builtin function '__builtin_ctz'
     81 | static inline int __builtin_ctz(unsigned int x)
        |                   ^
  1 warning and 1 error generated.
```