### PR TITLE
Fix armv7 gcc build with -march=armv8-a

### DIFF
--- a/celt/arm/mathops_arm.h
+++ b/celt/arm/mathops_arm.h
@@ -37,7 +37,7 @@
 
 static inline int32x4_t vroundf(float32x4_t x)
 {
-#  if defined(__aarch64__) || (defined(__ARM_ARCH) && __ARM_ARCH >= 8)
+#  if defined(__aarch64__) || (defined(__ARM_ARCH) && __ARM_ARCH >= 8 && defined(__clang__))
     return vcvtaq_s32_f32(x);
 #  else
     uint32x4_t sign = vandq_u32(vreinterpretq_u32_f32(x), vdupq_n_u32(0x80000000));


### PR DESCRIPTION
Like vcvtnq_s32_f32 in dnn/vec_neon.h, gcc only exposes vcvtaq_s32_f32 in aarch64 mode, unlike clang which supports it with -march=armv8-a.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95399