### PR TITLE
arm: do not export symbols from external asm

### DIFF
--- a/celt/arm/arm2gnu.pl
+++ b/celt/arm/arm2gnu.pl
@@ -86,7 +86,7 @@ while (<>) {
     s/\bINCLUDE[ \t]*([^ \t\n]+)/.include \"$1\"/;
     s/\bGET[ \t]*([^ \t\n]+)/.include \"${ my $x=$1; $x =~ s|\.s|-gnu.S|; \$x }\"/;
     s/\bIMPORT\b/.extern/;
-    s/\bEXPORT\b\s*/.global $symprefix/;
+    s/\bEXPORT[ \t]*([^ \t\n]+)/.hidden $symprefix$1\n.global $symprefix$1/;
     s/^(\s+)\[/$1IF/;
     s/^(\s+)\|/$1ELSE/;
     s/^(\s+)\]/$1ENDIF/;


### PR DESCRIPTION
celt_pitch_xcorr_edsp and celt_pitch_xcorr_neon are exported from libopus.so, since -fvisibility=hidden only works for C.
We can add ".hidden" in addition to ".global" to fix the visibilty.