### PR TITLE
silk: Add Arm NEON silk_VAD_GetSA_Q8

### DIFF
--- a/silk/arm/VAD_arm.h
+++ b/silk/arm/VAD_arm.h
@@ -1,0 +1,69 @@
+/* Copyright (c) 2026 Xiph.Org Foundation */
+/*
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef SILK_VAD_ARM_H
+#define SILK_VAD_ARM_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#if defined(OPUS_ARM_MAY_HAVE_NEON_INTR)
+
+/* When NEON is enabled, silk_VAD_GetNoiseLevels is exported (rather than a
+   static inline in VAD.c) so the NEON silk_VAD_GetSA_Q8 can call it, mirroring
+   the x86 path. */
+void silk_VAD_GetNoiseLevels(
+    const opus_int32            pX[ VAD_N_BANDS ],
+    silk_VAD_state              *psSilk_VAD
+);
+
+opus_int silk_VAD_GetSA_Q8_neon(
+    silk_encoder_state          *psEncC,
+    const opus_int16            pIn[]
+);
+
+#if defined(OPUS_ARM_PRESUME_NEON_INTR)
+
+#define OVERRIDE_silk_VAD_GetSA_Q8
+#define silk_VAD_GetSA_Q8(psEnC, pIn, arch) \
+    ((void)(arch), silk_VAD_GetSA_Q8_neon(psEnC, pIn))
+
+#elif defined(OPUS_HAVE_RTCD)
+
+#define OVERRIDE_silk_VAD_GetSA_Q8
+extern opus_int (*const SILK_VAD_GETSA_Q8_IMPL[OPUS_ARCHMASK + 1])(
+    silk_encoder_state          *psEncC,
+    const opus_int16            pIn[]
+);
+#define silk_VAD_GetSA_Q8(psEnC, pIn, arch) \
+    ((*SILK_VAD_GETSA_Q8_IMPL[(arch) & OPUS_ARCHMASK])(psEnC, pIn))
+
+#endif
+
+#endif /* OPUS_ARM_MAY_HAVE_NEON_INTR */
+
+#endif /* SILK_VAD_ARM_H */

--- a/silk/arm/VAD_neon_intr.c
+++ b/silk/arm/VAD_neon_intr.c
@@ -1,77 +1,39 @@
-/***********************************************************************
-Copyright (c) 2006-2011, Skype Limited. All rights reserved.
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-- Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-- Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-- Neither the name of Internet Society, IETF or IETF Trust, nor the
-names of specific contributors, may be used to endorse or promote
-products derived from this software without specific prior written
-permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-***********************************************************************/
+/* Copyright (c) 2026 Xiph.Org Foundation
+   Arm NEON port of the SSE4.1 implementation by
+   XiangMingZhu WeiZhou MinPeng YanWang FrancisQuiers (Cisco Systems, INC)
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
+#include <arm_neon.h>
+
 #include "main.h"
 #include "stack_alloc.h"
-
-/* Silk VAD noise level estimation */
-# if !defined(OPUS_X86_MAY_HAVE_SSE4_1) && !defined(OPUS_ARM_MAY_HAVE_NEON_INTR)
-static OPUS_INLINE void silk_VAD_GetNoiseLevels(
-    const opus_int32             pX[ VAD_N_BANDS ], /* I    subband energies                            */
-    silk_VAD_state              *psSilk_VAD         /* I/O  Pointer to Silk VAD state                   */
-);
-#endif
-
-/**********************************/
-/* Initialization of the Silk VAD */
-/**********************************/
-opus_int silk_VAD_Init(                                         /* O    Return value, 0 if success                  */
-    silk_VAD_state              *psSilk_VAD                     /* I/O  Pointer to Silk VAD state                   */
-)
-{
-    opus_int b, ret = 0;
-
-    /* reset state memory */
-    silk_memset( psSilk_VAD, 0, sizeof( silk_VAD_state ) );
-
-    /* init noise levels */
-    /* Initialize array with approx pink noise levels (psd proportional to inverse of frequency) */
-    for( b = 0; b < VAD_N_BANDS; b++ ) {
-        psSilk_VAD->NoiseLevelBias[ b ] = silk_max_32( silk_DIV32_16( VAD_NOISE_LEVELS_BIAS, b + 1 ), 1 );
-    }
-
-    /* Initialize state */
-    for( b = 0; b < VAD_N_BANDS; b++ ) {
-        psSilk_VAD->NL[ b ]     = silk_MUL( 100, psSilk_VAD->NoiseLevelBias[ b ] );
-        psSilk_VAD->inv_NL[ b ] = silk_DIV32( silk_int32_MAX, psSilk_VAD->NL[ b ] );
-    }
-    psSilk_VAD->counter = 15;
-
-    /* init smoothed energy-to-noise ratio*/
-    for( b = 0; b < VAD_N_BANDS; b++ ) {
-        psSilk_VAD->NrgRatioSmth_Q8[ b ] = 100 * 256;       /* 100 * 256 --> 20 dB SNR */
-    }
-
-    return( ret );
-}
 
 /* Weighting factors for tilt measure */
 static const opus_int32 tiltWeights[ VAD_N_BANDS ] = { 30000, 6000, -12000, -12000 };
@@ -79,9 +41,9 @@ static const opus_int32 tiltWeights[ VAD_N_BANDS ] = { 30000, 6000, -12000, -120
 /***************************************/
 /* Get the speech activity level in Q8 */
 /***************************************/
-opus_int silk_VAD_GetSA_Q8_c(                                   /* O    Return value, 0 if success                  */
-    silk_encoder_state          *psEncC,                        /* I/O  Encoder state                               */
-    const opus_int16            pIn[]                           /* I    PCM input                                   */
+opus_int silk_VAD_GetSA_Q8_neon(                    /* O    Return value, 0 if success                  */
+    silk_encoder_state          *psEncC,            /* I/O  Encoder state                               */
+    const opus_int16            pIn[]               /* I    PCM input                                   */
 )
 {
     opus_int   SA_Q15, pSNR_dB_Q7, input_tilt;
@@ -97,7 +59,16 @@ opus_int silk_VAD_GetSA_Q8_c(                                   /* O    Return v
     opus_int   X_offset[ VAD_N_BANDS ];
     opus_int   ret = 0;
     silk_VAD_state *psSilk_VAD = &psEncC->sVAD;
+
     SAVE_STACK;
+
+#ifdef OPUS_CHECK_ASM
+    silk_encoder_state psEncC_c;
+    opus_int ret_c;
+
+    silk_memcpy( &psEncC_c, psEncC, sizeof( psEncC_c ) );
+    ret_c = silk_VAD_GetSA_Q8_c( &psEncC_c, pIn );
+#endif
 
     /* Safety checks */
     silk_assert( VAD_N_BANDS == 4 );
@@ -165,8 +136,25 @@ opus_int silk_VAD_GetSA_Q8_c(                                   /* O    Return v
         /* initialize with summed energy of last subframe */
         Xnrg[ b ] = psSilk_VAD->XnrgSubfr[ b ];
         for( s = 0; s < VAD_INTERNAL_SUBFRAMES; s++ ) {
+            int32x4_t acc_s32x4;
             sumSquared = 0;
-            for( i = 0; i < dec_subframe_length; i++ ) {
+
+            acc_s32x4 = vdupq_n_s32( 0 );
+
+            /* Process 8 samples per iteration: ( X[i] >> 3 )^2, summed in int32
+               lanes. Bit-exact with the C reference (exact integer sum of
+               squares; no overflow for dec_subframe_length <= 128). */
+            for( i = 0; i < dec_subframe_length - 7; i += 8 )
+            {
+                int16x8_t x_s16x8 = vld1q_s16( &X[ X_offset[ b ] + i + dec_subframe_offset ] );
+                x_s16x8   = vshrq_n_s16( x_s16x8, 3 );
+                acc_s32x4 = vmlal_s16( acc_s32x4, vget_low_s16(  x_s16x8 ), vget_low_s16(  x_s16x8 ) );
+                acc_s32x4 = vmlal_s16( acc_s32x4, vget_high_s16( x_s16x8 ), vget_high_s16( x_s16x8 ) );
+            }
+
+            sumSquared += vaddvq_s32( acc_s32x4 );
+
+            for( ; i < dec_subframe_length; i++ ) {
                 /* The energy will be less than dec_subframe_length * ( silk_int16_MIN / 8 ) ^ 2.            */
                 /* Therefore we can accumulate with no risk of overflow (unless dec_subframe_length > 128)  */
                 x_tmp = silk_RSHIFT(
@@ -290,71 +278,11 @@ opus_int silk_VAD_GetSA_Q8_c(                                   /* O    Return v
         psEncC->input_quality_bands_Q15[ b ] = silk_sigm_Q15( silk_RSHIFT( SNR_Q7 - 16 * 128, 4 ) );
     }
 
+#ifdef OPUS_CHECK_ASM
+    silk_assert( ret == ret_c );
+    silk_assert( !memcmp( &psEncC_c, psEncC, sizeof( psEncC_c ) ) );
+#endif
+
     RESTORE_STACK;
     return( ret );
-}
-
-/**************************/
-/* Noise level estimation */
-/**************************/
-# if  !defined(OPUS_X86_MAY_HAVE_SSE4_1) && !defined(OPUS_ARM_MAY_HAVE_NEON_INTR)
-static OPUS_INLINE
-#endif
-void silk_VAD_GetNoiseLevels(
-    const opus_int32            pX[ VAD_N_BANDS ],  /* I    subband energies                            */
-    silk_VAD_state              *psSilk_VAD         /* I/O  Pointer to Silk VAD state                   */
-)
-{
-    opus_int   k;
-    opus_int32 nl, nrg, inv_nrg;
-    opus_int   coef, min_coef;
-
-    /* Initially faster smoothing */
-    if( psSilk_VAD->counter < 1000 ) { /* 1000 = 20 sec */
-        min_coef = silk_DIV32_16( silk_int16_MAX, silk_RSHIFT( psSilk_VAD->counter, 4 ) + 1 );
-        /* Increment frame counter */
-        psSilk_VAD->counter++;
-    } else {
-        min_coef = 0;
-    }
-
-    for( k = 0; k < VAD_N_BANDS; k++ ) {
-        /* Get old noise level estimate for current band */
-        nl = psSilk_VAD->NL[ k ];
-        silk_assert( nl >= 0 );
-
-        /* Add bias */
-        nrg = silk_ADD_POS_SAT32( pX[ k ], psSilk_VAD->NoiseLevelBias[ k ] );
-        silk_assert( nrg > 0 );
-
-        /* Invert energies */
-        inv_nrg = silk_DIV32( silk_int32_MAX, nrg );
-        silk_assert( inv_nrg >= 0 );
-
-        /* Less update when subband energy is high */
-        if( nrg > silk_LSHIFT( nl, 3 ) ) {
-            coef = VAD_NOISE_LEVEL_SMOOTH_COEF_Q16 >> 3;
-        } else if( nrg < nl ) {
-            coef = VAD_NOISE_LEVEL_SMOOTH_COEF_Q16;
-        } else {
-            coef = silk_SMULWB( silk_SMULWW( inv_nrg, nl ), VAD_NOISE_LEVEL_SMOOTH_COEF_Q16 << 1 );
-        }
-
-        /* Initially faster smoothing */
-        coef = silk_max_int( coef, min_coef );
-
-        /* Smooth inverse energies */
-        psSilk_VAD->inv_NL[ k ] = silk_SMLAWB( psSilk_VAD->inv_NL[ k ], inv_nrg - psSilk_VAD->inv_NL[ k ], coef );
-        silk_assert( psSilk_VAD->inv_NL[ k ] >= 0 );
-
-        /* Compute noise level by inverting again */
-        nl = silk_DIV32( silk_int32_MAX, psSilk_VAD->inv_NL[ k ] );
-        silk_assert( nl >= 0 );
-
-        /* Limit noise levels (guarantee 7 bits of head room) */
-        nl = silk_min( nl, 0x00FFFFFF );
-
-        /* Store as part of state */
-        psSilk_VAD->NL[ k ] = nl;
-    }
 }

--- a/silk/arm/arm_silk_map.c
+++ b/silk/arm/arm_silk_map.c
@@ -37,6 +37,17 @@ POSSIBILITY OF SUCH DAMAGE.
 # if (defined(OPUS_ARM_MAY_HAVE_NEON_INTR) && \
  !defined(OPUS_ARM_PRESUME_NEON_INTR))
 
+opus_int (*const SILK_VAD_GETSA_Q8_IMPL[OPUS_ARCHMASK + 1])(
+        silk_encoder_state          *psEncC,            /* I/O  Encoder state                               */
+        const opus_int16            pIn[]               /* I    PCM input                                   */
+) = {
+      silk_VAD_GetSA_Q8_c,    /* ARMv4 */
+      silk_VAD_GetSA_Q8_c,    /* EDSP */
+      silk_VAD_GetSA_Q8_c,    /* Media */
+      silk_VAD_GetSA_Q8_neon, /* Neon */
+      silk_VAD_GetSA_Q8_neon, /* dotprod */
+};
+
 void (*const SILK_BIQUAD_ALT_STRIDE2_IMPL[OPUS_ARCHMASK + 1])(
         const opus_int16            *in,                /* I     input signal                                               */
         const opus_int32            *B_Q28,             /* I     MA coefficients [3]                                        */

--- a/silk/main.h
+++ b/silk/main.h
@@ -44,6 +44,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #if (defined(OPUS_ARM_ASM) || defined(OPUS_ARM_MAY_HAVE_NEON_INTR))
 #include "arm/NSQ_del_dec_arm.h"
+#include "arm/VAD_arm.h"
 #endif
 
 /* Convert Left/Right stereo signal to adaptive Mid/Side representation */

--- a/silk_sources.mk
+++ b/silk_sources.mk
@@ -96,7 +96,8 @@ SILK_SOURCES_ARM_NEON_INTR = \
 silk/arm/biquad_alt_neon_intr.c \
 silk/arm/LPC_inv_pred_gain_neon_intr.c \
 silk/arm/NSQ_del_dec_neon_intr.c \
-silk/arm/NSQ_neon.c
+silk/arm/NSQ_neon.c \
+silk/arm/VAD_neon_intr.c
 
 SILK_SOURCES_FIXED = \
 silk/fixed/LTP_analysis_filter_FIX.c \


### PR DESCRIPTION
## Summary

`silk_VAD_GetSA_Q8` had an x86 SSE4.1 implementation but **no Arm one**, even though it runs on every SILK/hybrid frame in the default (float) build. This adds a NEON version, mirroring the SSE4.1 one.

## What's vectorised
The per-subframe energy **sum-of-squares** — `(X[i] >> 3)^2` accumulated in int32 — 8 samples per iteration via `vshrq_n_s16` + paired `vmlal_s16` (low/high), with a scalar tail and a horizontal `vaddvq_s32`. Everything else (analysis filterbank, noise estimation, SNR/tilt) is identical to the C reference, exactly as the SSE4.1 version does.

- **Bit-exact** with `silk_VAD_GetSA_Q8_c` (exact integer sum of squares, no overflow), validated by the existing `OPUS_CHECK_ASM` full-encoder-state `memcmp`.
- As on x86, `silk_VAD_GetNoiseLevels` becomes exported (instead of `static inline` in `VAD.c`) when NEON is enabled, so the kernel can call it.

## Dispatch / wiring
Uses the existing `OVERRIDE_silk_VAD_GetSA_Q8` hook: a new `silk/arm/VAD_arm.h` provides the PRESUME (direct call) and RTCD (`SILK_VAD_GETSA_Q8_IMPL` table in `arm_silk_map.c`) dispatch, mirroring `silk/x86/main_sse.h`. The source is added to the common `SILK_SOURCES_ARM_NEON_INTR` group, which is already wired in autotools / CMake / Meson — so no build-system changes are needed.

## Numbers (Apple M4)
- Microbench of the vectorised loop at the real subband lengths (10–80 samples): **~1.1–1.7×** over scalar.
- End-to-end within run-to-run noise (VAD is a small per-frame cost), bitstream unchanged (bit-exact).
- Full meson test suite passes.

This is the last of the silk-side x86-has-it/ARM-doesn't parity gaps that runs in the default build.
