### PR TITLE
Reject a frame_size whose duration check would overflow (fixes #491)

### DIFF
--- a/src/opus_encoder.c
+++ b/src/opus_encoder.c
@@ -842,6 +842,13 @@ opus_int32 frame_size_select(int application, opus_int32 frame_size, int variabl
       return -1;
    if (new_size>frame_size)
       return -1;
+   /* Every legal duration below is at most 6*Fs/50 (120 ms), so a caller
+      passing a frame_size large enough to overflow the multiplications
+      that follow can only be trying to smuggle through an out-of-range
+      value: new_size can't legitimately reach here already bigger than
+      Fs itself, so reject it before the overflow-prone checks run. */
+   if (new_size>Fs)
+      return -1;
    if (400*new_size!=Fs   && 200*new_size!=Fs   && 100*new_size!=Fs   &&
         50*new_size!=Fs   &&  25*new_size!=Fs   &&  50*new_size!=3*Fs &&
         50*new_size!=4*Fs &&  50*new_size!=5*Fs &&  50*new_size!=6*Fs)

--- a/tests/opus_encode_regressions.c
+++ b/tests/opus_encode_regressions.c
@@ -1458,9 +1458,31 @@ int qext_dred_combination(void)
 #endif
 
 
+static int frame_size_select_overflow(void)
+{
+    /* GH-491: 200*new_size wraps to exactly equal Fs (8000) for this
+       frame_size, so every branch of frame_size_select()'s validity
+       check that used to rely on that multiplication was defeated,
+       letting an enormous frame_size straight through to a stack
+       allocation sized by it in opus_encode(). */
+    OpusEncoder *enc;
+    int err;
+    unsigned char data[2000];
+    short pcm[2];
+    int ret;
+
+    enc = opus_encoder_create(8000, 1, OPUS_APPLICATION_AUDIO, &err);
+    opus_test_assert(err == OPUS_OK);
+    ret = opus_encode(enc, pcm, 1073741864, data, sizeof(data));
+    opus_test_assert(ret == OPUS_BAD_ARG);
+    opus_encoder_destroy(enc);
+    return 0;
+}
+
 void regression_test(void)
 {
    fprintf(stderr, "Running simple tests for bugs that have been fixed previously\n");
+   frame_size_select_overflow();
    celt_ec_internal_error();
    mscbr_encode_fail10();
    mscbr_encode_fail();


### PR DESCRIPTION
Fixes #491.

frame_size_select() validates a caller-supplied frame_size against every legal duration using multiplications like 200*new_size!=Fs. For a large enough new_size that multiplication wraps around, and for the specific value in the report (1073741864 at 8000 Hz) it happens to wrap to exactly 8000, so every branch of the check reports "this matches a legal duration" and the huge value comes straight back out.

opus_encode() trusts that return value and sizes a stack allocation with it, so this isn't just a validation gap, it's a reachable stack corruption crash from public API input. I confirmed this locally: reverting just the fix and running the existing test suite segfaults immediately at the new regression test.

The fix adds one bound check before the overflow-prone multiplications run. Every legal duration tops out at 6*Fs/50 (120ms), so a new_size already bigger than Fs itself can never be one of them, and rejecting it there doesn't touch the legitimate range at all.

Added a test to opus_encode_regressions.c using the exact frame_size/sample-rate pair from the report, checking for OPUS_BAD_ARG instead of a crash. Full local test suite passes.