### PR TITLE
Update Windows CI for Visual Studio 2026

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -91,22 +91,16 @@ jobs:
             args: "-DCMAKE_TOOLCHAIN_FILE=${ANDROID_HOME}/ndk/${NDK_VERSION}/build/cmake/android.toolchain.cmake -DANDROID_ABI=x86_64 -DBUILD_SHARED_LIBS=ON"
           }
         - {
-            name: "Windows/Dll/X86/Release",
-            os: windows-latest,
-            config: Release,
-            args: -G "Visual Studio 17 2022" -A Win32 -DBUILD_SHARED_LIBS=ON
-          }
-        - {
             name: "Windows/Dll/X64/Release",
             os: windows-latest,
             config: Release,
-            args: -G "Visual Studio 17 2022" -A Win32 -DBUILD_SHARED_LIBS=ON
+            args: -G "Visual Studio 18 2026" -A x64 -DBUILD_SHARED_LIBS=ON
           }
         - {
             name: "Windows/Dll/ARMv8/Release",
             os: windows-latest,
             config: Release,
-            args: -G "Visual Studio 17 2022" -A ARM64 -DBUILD_SHARED_LIBS=ON
+            args: -G "Visual Studio 18 2026" -A ARM64 -DBUILD_SHARED_LIBS=ON
           }
         - {
             name: "Linux/So/X64/Release",
@@ -141,22 +135,16 @@ jobs:
             args: -G "Unix Makefiles" -DBUILD_FRAMEWORK=ON -DCMAKE_INSTALL_PREFIX=install -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES=arm64
           }
         - {
-            name: "Windows/Lib/X86/Release",
-            os: windows-latest,
-            config: Release,
-            args: -G "Visual Studio 17 2022" -A Win32
-          }
-        - {
             name: "Windows/Lib/X64/Release",
             os: windows-latest,
             config: Release,
-            args: -G "Visual Studio 17 2022" -A Win32
+            args: -G "Visual Studio 18 2026" -A x64
           }
         - {
             name: "Windows/Lib/armv8/Release",
             os: windows-latest,
             config: Release,
-            args: -G "Visual Studio 17 2022" -A ARM64
+            args: -G "Visual Studio 18 2026" -A ARM64
           }
         - {
             name: "Linux/Lib/X64/Release",
@@ -212,7 +200,7 @@ jobs:
             name: "AssertionsFuzz/Windows/Lib/X64/Release",
             os: windows-latest,
             config: Release,
-            args: -G "Visual Studio 17 2022" -A Win32 -DOPUS_ASSERTIONS=ON -DOPUS_FUZZING=ON
+            args: -G "Visual Studio 18 2026" -A x64 -DOPUS_ASSERTIONS=ON -DOPUS_FUZZING=ON
           }
         - {
             name: "AssertionsFuzz/Linux/Lib/X64/Release",

--- a/.github/workflows/dred.yml
+++ b/.github/workflows/dred.yml
@@ -18,13 +18,13 @@ jobs:
             name: "Windows/Lib/X64/Release",
             os: windows-latest,
             config: Release,
-            args: -G "Visual Studio 17 2022" -DOPUS_X86_PRESUME_AVX2=ON
+            args: -G "Visual Studio 18 2026" -A x64 -DOPUS_X86_PRESUME_AVX2=ON
           }
         - {
            name: "Windows/Lib/armv8/Release",
            os: windows-latest,
            config: Release,
-           args: -G "Visual Studio 17 2022" -A ARM64
+           args: -G "Visual Studio 18 2026" -A ARM64
           }
         - {
             name: "Linux/Lib/X64/Release",


### PR DESCRIPTION
Fixes #497

- Use Visual Studio 2026 on `windows-latest`.
- Build Windows x64 jobs with `-A x64`.
- Remove Win32 jobs because Windows 10 is no longer supported and Windows 11 has no 32-bit edition.